### PR TITLE
Updated library version to 1.0.3 in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ include in app level build.gradle
  }
  ```
 ```groovy
- implementation  'io.ak1:drawbox:1.0.2'
+ implementation  'io.ak1:drawbox:1.0.3'
 ```
 or Maven:
 ```xml
 <dependency>
   <groupId>io.ak1</groupId>
   <artifactId>drawbox</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <type>pom</type>
 </dependency>
 ```
 or ivy:
 ```xml
-<dependency org='io.ak1' name='drawbox' rev='1.0.2'>
+<dependency org='io.ak1' name='drawbox' rev='1.0.3'>
   <artifact name='drawbox' ext='pom' ></artifact>
 </dependency>
 ```


### PR DESCRIPTION
The README showed version 1.0.2 in the examples, which did not work on my machine for some reason. The newer version works flawless though 