### PR TITLE
fix: svg export crash on wasmJs target

### DIFF
--- a/shared/src/wasmJsMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.wasmJs.kt
@@ -40,10 +40,9 @@ private class WasmJsImageSaver : ImageSaver {
         URL.revokeObjectURL(url)
     }
 
-    @Suppress("UNCHECKED_CAST")
     override fun saveSvg(svgContent: String) {
         val parts = JsArray<JsAny?>()
-        parts[0] = svgContent as JsAny?
+        parts[0] = svgContent.toJsString()
         val blob = Blob(parts, BlobPropertyBag(type = "image/svg+xml"))
         val url = URL.createObjectURL(blob)
         val anchor = document.createElement("a") as HTMLAnchorElement


### PR DESCRIPTION
fix: svg export crash on wasmJs target

  Convert Kotlin String to JsString via toJsString() instead of using an
  unchecked cast to JsAny?, which threw a RuntimeException when building
  the Blob for SVG export in the browser.

  Fixes #56