### PR TITLE
feat: add JSON import/export for the sample app

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Event.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Event.kt
@@ -9,6 +9,7 @@ sealed class Event {
     data class HistoryChanged(val canUndo: Boolean, val canRedo: Boolean) : Event()
     data class PngSaved(val bitmap: ImageBitmap?, val throwable: Throwable?) : Event()
     data class SvgExported(val svg: String) : Event()
+    data class JsonExported(val json: String) : Event()
     data class DrawingLoaded(val state: State) : Event()
     data class Error(val message: String, val throwable: Throwable? = null) : Event()
 }

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -202,7 +202,7 @@ class DrawBoxController(
      *
      * @return JSON string representation of the drawing
      */
-    fun exportPath(): String {
+    internal fun exportPath(): String {
         val payLoad = PayLoad(
             bgColor = _state.value.bgColor,
             elements = _state.value.elements
@@ -221,6 +221,15 @@ class DrawBoxController(
             elements = _state.value.elements
         )
         _events.tryEmit(Event.SvgExported(svgContent))
+    }
+
+    /**
+     * Export the current drawing as JSON.
+     *
+     * Emits an [Event.JsonExported] event so the platform layer can persist it.
+     */
+    fun exportJson() {
+        _events.tryEmit(Event.JsonExported(exportPath()))
     }
 
     /**

--- a/shared/src/androidMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.android.kt
+++ b/shared/src/androidMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.android.kt
@@ -71,12 +71,24 @@ private class AndroidImageSaver(private val context: Context) : ImageSaver {
     }
 
     override fun saveSvg(svgContent: String) {
+        saveTextFile(svgContent, "svg", "image/svg+xml")
+    }
+
+    override fun saveJson(jsonContent: String) {
+        saveTextFile(jsonContent, "json", "application/json")
+    }
+
+    override fun loadJson(onLoaded: (String) -> Unit) {
+        showToast("Import JSON is not supported from the Android sample yet")
+    }
+
+    private fun saveTextFile(content: String, extension: String, mimeType: String) {
         GlobalScope.launch(Dispatchers.IO) {
             try {
-                val fileName = "DrawBox-${System.currentTimeMillis()}.svg"
+                val fileName = "DrawBox-${System.currentTimeMillis()}.$extension"
                 val values = ContentValues().apply {
                     put(MediaStore.Files.FileColumns.DISPLAY_NAME, fileName)
-                    put(MediaStore.Files.FileColumns.MIME_TYPE, "image/svg+xml")
+                    put(MediaStore.Files.FileColumns.MIME_TYPE, mimeType)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         put(
                             MediaStore.MediaColumns.RELATIVE_PATH,
@@ -89,12 +101,12 @@ private class AndroidImageSaver(private val context: Context) : ImageSaver {
                 val uri = resolver.insert(MediaStore.Files.getContentUri("external"), values)
 
                 if (uri == null) {
-                    showToast("Failed to create SVG file")
+                    showToast("Failed to create $extension file")
                     return@launch
                 }
 
                 resolver.openOutputStream(uri)?.use { out ->
-                    out.write(svgContent.toByteArray())
+                    out.write(content.toByteArray())
                 }
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -105,10 +117,10 @@ private class AndroidImageSaver(private val context: Context) : ImageSaver {
                         null,
                     )
                 }
-                showToast("SVG saved successfully!")
+                showToast("${extension.uppercase()} saved successfully!")
             } catch (e: Throwable) {
-                android.util.Log.e("ImageSaver", "Error saving SVG", e)
-                showToast("Error saving SVG: ${e.message}")
+                android.util.Log.e("ImageSaver", "Error saving $extension", e)
+                showToast("Error saving $extension: ${e.message}")
             }
         }
     }

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.kt
@@ -16,6 +16,16 @@ interface ImageSaver {
      * Save SVG content as SVG file
      */
     fun saveSvg(svgContent: String)
+
+    /**
+     * Save drawing JSON to a file the user can keep.
+     */
+    fun saveJson(jsonContent: String)
+
+    /**
+     * Prompt the user to pick a JSON file and deliver its contents to [onLoaded].
+     */
+    fun loadJson(onLoaded: (String) -> Unit)
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -38,6 +38,10 @@ fun HomeScreen() {
                     imageSaver.saveSvg(event.svg)
                 }
 
+                is Event.JsonExported -> {
+                    imageSaver.saveJson(event.json)
+                }
+
                 else -> {}
             }
         }
@@ -94,6 +98,9 @@ fun HomeScreen() {
         },
         onSizeSelected = { size ->
             viewModel.setStrokeWidth(size)
+        },
+        onImportJson = {
+            imageSaver.loadJson { json -> viewModel.importPath(json) }
         },
     )
 }

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ControlsBar.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ControlsBar.kt
@@ -62,6 +62,7 @@ fun ControlsBar(
     onSizeClick: () -> Unit,
     onModeSelected: (Mode) -> Unit,
     onSizeSelected: (Float) -> Unit,
+    onImportJson: () -> Unit,
 ) {
     val active = MaterialTheme.colorScheme.primary
     val inactive = MaterialTheme.colorScheme.surfaceVariant
@@ -239,9 +240,12 @@ fun ControlsBar(
             }
         }
 
-        SettingsMenu(viewModel, settingsMenuExpanded) {
-            settingsMenuExpanded = it
-        }
+        SettingsMenu(
+            viewModel = viewModel,
+            menuExpanded = settingsMenuExpanded,
+            onImportJson = onImportJson,
+            onMenuClick = { settingsMenuExpanded = it },
+        )
     }
 
 
@@ -295,7 +299,10 @@ private fun RowScope.SizeMenuItem(
 
 @Composable
 fun BoxScope.SettingsMenu(
-    viewModel: DrawBoxController, menuExpanded: Boolean, onMenuClick: (Boolean) -> Unit
+    viewModel: DrawBoxController,
+    menuExpanded: Boolean,
+    onImportJson: () -> Unit,
+    onMenuClick: (Boolean) -> Unit,
 ) {
     Box(modifier = Modifier.align(Alignment.TopEnd).padding(8.dp)) {
         IconButton(
@@ -330,7 +337,7 @@ fun BoxScope.SettingsMenu(
                 text = { Text("Export JSON") },
                 leadingIcon = { Icon(painterResource(DrawBoxIcons.Export), "Json Export") },
                 onClick = {
-                    // TODO: Implement JSON export
+                    viewModel.exportJson()
                     onMenuClick.invoke(false)
                 })
 
@@ -338,7 +345,7 @@ fun BoxScope.SettingsMenu(
                 text = { Text("Import JSON") },
                 leadingIcon = { Icon(painterResource(DrawBoxIcons.Import), "Json Import") },
                 onClick = {
-                    // TODO: Implement JSON import
+                    onImportJson()
                     onMenuClick.invoke(false)
                 })
         }

--- a/shared/src/iosMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.ios.kt
+++ b/shared/src/iosMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.ios.kt
@@ -59,4 +59,18 @@ private class IosImageSaver : ImageSaver {
             NSLog("Error exporting SVG: ${e.message}")
         }
     }
+
+    override fun saveJson(jsonContent: String) {
+        try {
+            val fileName = "DrawBox-${Clock.System.now().nanosecondsOfSecond}.json"
+            NSLog("JSON export created: $fileName")
+            NSLog("JSON content length: ${jsonContent.length} characters")
+        } catch (e: Exception) {
+            NSLog("Error exporting JSON: ${e.message}")
+        }
+    }
+
+    override fun loadJson(onLoaded: (String) -> Unit) {
+        NSLog("Import JSON is not supported from the iOS sample yet")
+    }
 }

--- a/shared/src/jvmMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.jvm.kt
@@ -42,4 +42,28 @@ private class DesktopImageSaver : ImageSaver {
         target.writeText(svgContent)
         println("SVG saved to: ${target.absolutePath}")
     }
+
+    override fun saveJson(jsonContent: String) {
+        val chooser = JFileChooser().apply {
+            dialogTitle = "Export Drawing as JSON"
+            fileFilter = FileNameExtensionFilter("DrawBox JSON", "json")
+            selectedFile = File("DrawBox-${System.currentTimeMillis()}.json")
+        }
+        if (chooser.showSaveDialog(null) != JFileChooser.APPROVE_OPTION) return
+        val target = chooser.selectedFile.let {
+            if (it.extension.equals("json", ignoreCase = true)) it else File("${it.absolutePath}.json")
+        }
+        target.writeText(jsonContent)
+        println("JSON saved to: ${target.absolutePath}")
+    }
+
+    override fun loadJson(onLoaded: (String) -> Unit) {
+        val chooser = JFileChooser().apply {
+            dialogTitle = "Import Drawing from JSON"
+            fileFilter = FileNameExtensionFilter("DrawBox JSON", "json")
+        }
+        if (chooser.showOpenDialog(null) != JFileChooser.APPROVE_OPTION) return
+        val source = chooser.selectedFile ?: return
+        onLoaded(source.readText())
+    }
 }

--- a/shared/src/wasmJsMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.wasmJs.kt
@@ -12,9 +12,12 @@ import org.jetbrains.skia.Image
 import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.set
 import org.w3c.dom.HTMLAnchorElement
+import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.events.Event as DomEvent
 import org.w3c.dom.url.URL
 import org.w3c.files.Blob
 import org.w3c.files.BlobPropertyBag
+import org.w3c.files.FileReader
 import kotlin.time.Clock
 import kotlin.js.ExperimentalWasmJsInterop
 
@@ -50,5 +53,34 @@ private class WasmJsImageSaver : ImageSaver {
         anchor.download = "DrawBox-${Clock.System.now().nanosecondsOfSecond}.svg"
         anchor.click()
         URL.revokeObjectURL(url)
+    }
+
+    override fun saveJson(jsonContent: String) {
+        val parts = JsArray<JsAny?>()
+        parts[0] = jsonContent.toJsString()
+        val blob = Blob(parts, BlobPropertyBag(type = "application/json"))
+        val url = URL.createObjectURL(blob)
+        val anchor = document.createElement("a") as HTMLAnchorElement
+        anchor.href = url
+        anchor.download = "DrawBox-${Clock.System.now().nanosecondsOfSecond}.json"
+        anchor.click()
+        URL.revokeObjectURL(url)
+    }
+
+    override fun loadJson(onLoaded: (String) -> Unit) {
+        val input = document.createElement("input") as HTMLInputElement
+        input.type = "file"
+        input.accept = "application/json,.json"
+        input.onchange = { _: DomEvent ->
+            val file = input.files?.item(0)
+            if (file != null) {
+                val reader = FileReader()
+                reader.onload = { _: DomEvent ->
+                    onLoaded(reader.result.toString())
+                }
+                reader.readAsText(file)
+            }
+        }
+        input.click()
     }
 }


### PR DESCRIPTION
- expose DrawBoxController.exportJson() emitting Event.JsonExported
- wire Export/Import JSON menu actions in ControlsBar/HomeScreen
 - implement saveJson/loadJson per platform: JFileChooser (JVM),
    MediaStore via shared text-file helper (Android), browser
    download + file input (WASM), stub logs (iOS)