### PR TITLE
Feature/62 add ability to add svg in background

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -8,20 +8,40 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageShader
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import io.ak1.drawbox.domain.model.BackgroundPattern
 import io.ak1.drawbox.domain.model.Element
 import io.ak1.drawbox.domain.model.Intent
 import io.ak1.drawbox.domain.model.State
@@ -50,9 +70,12 @@ import kotlin.math.sqrt
  * - **RECTANGLE/CIRCLE/TRIANGLE/ARROW/LINE**: Tap/drag creates [Element.Shape] of that type
  *
  * **Rendering Pipeline:**
- * 1. Sort elements by [Element.zIndex] (lower values render first)
- * 2. Render each element using [renderElement]
- * 3. Paths are rendered with strokes, shapes with their specific geometry
+ * 1. Solid [State.bgColor] fill
+ * 2. Optional [State.bgPattern] tiled via a cached [ShaderBrush] (rasterized once
+ *    per pattern change with tint baked in; per-frame cost is a single `drawRect`)
+ * 3. Sort elements by [Element.zIndex] (lower values render first)
+ * 4. Render each element using [renderElement]
+ * 5. Paths are rendered with strokes, shapes with their specific geometry
  *
  * **Architecture:**
  * ```
@@ -70,6 +93,8 @@ import kotlin.math.sqrt
  * **Performance Notes:**
  * - Uses [rememberGraphicsLayer] to render elements efficiently
  * - Pointer input is keyed by [state.mode] to update on mode changes
+ * - [State.bgPattern] is converted to a tiled [ShaderBrush] via [remember];
+ *   per-frame work is a single `drawRect` rather than an N×M painter tile loop
  * - Large element lists may impact frame rate; consider implementing virtualization
  * - On-screen canvas changes are tracked via state hashCode
  *
@@ -81,6 +106,7 @@ import kotlin.math.sqrt
  * @see Intent
  * @see Mode
  * @see Element
+ * @see BackgroundPattern
  * @see renderElement for element-specific rendering
  */
 @Composable
@@ -113,9 +139,23 @@ fun DrawBox(
         Mode.PEN -> null
     }
 
+    // Rasterize + tile the pattern once per [bgPattern] / density / layoutDirection
+    // change. Without remember, every drag tick recomposes DrawBox, rebuilds the
+    // modifier chain, and re-tiles N×M painter draws per frame; with remember the
+    // per-frame work in `.drawBehind` collapses to a single shader-backed drawRect.
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val patternBrush: ShaderBrush? = remember(state.bgPattern, density, layoutDirection) {
+        state.bgPattern?.toTiledBrush(density, layoutDirection)
+    }
+
     Box(
         modifier = modifier
+            // Layering: solid bgColor → tiled bgPattern (if any) → graphicsLayer of strokes/shapes.
             .background(state.bgColor)
+            .drawBehind {
+                patternBrush?.let { drawRect(it) }
+            }
             .drawWithContent {
                 graphicsLayer.record { this@drawWithContent.drawContent() }
                 drawLayer(graphicsLayer)
@@ -159,6 +199,60 @@ fun DrawBox(
                 }
         }
     }
+}
+
+/**
+ * Build a [ShaderBrush] that tiles the pattern's painter across the canvas via a
+ * GPU-cached [ImageShader] with [TileMode.Repeated]. The painter is rasterized
+ * to an [ImageBitmap] at its intrinsic size (64dp square fallback), with the
+ * optional [BackgroundPattern.tint] baked in as a SrcIn color filter. Built once
+ * per pattern change and reused across recompositions, so per-frame work in
+ * `.drawBehind` reduces to a single [androidx.compose.ui.graphics.drawscope.DrawScope.drawRect] call.
+ */
+private fun BackgroundPattern.toTiledBrush(
+    density: Density,
+    layoutDirection: LayoutDirection,
+): ShaderBrush {
+    val intrinsic = painter.intrinsicSize
+    val tileSize = if (intrinsic.isSpecified && intrinsic.width > 0f && intrinsic.height > 0f) {
+        IntSize(
+            intrinsic.width.toInt().coerceAtLeast(1),
+            intrinsic.height.toInt().coerceAtLeast(1),
+        )
+    } else {
+        val fallback = with(density) { 64.dp.toPx().toInt() }.coerceAtLeast(1)
+        IntSize(fallback, fallback)
+    }
+    val bitmap = painter.rasterize(tileSize, density, layoutDirection, tint)
+    return ShaderBrush(
+        ImageShader(bitmap, TileMode.Repeated, TileMode.Repeated),
+    )
+}
+
+/**
+ * Render the painter into a freshly allocated [ImageBitmap] sized to [tileSize],
+ * applying an optional SrcIn [tint]. Used to bake a tileable bitmap for shader-based
+ * background tiling.
+ */
+private fun Painter.rasterize(
+    tileSize: IntSize,
+    density: Density,
+    layoutDirection: LayoutDirection,
+    tint: Color?,
+): ImageBitmap {
+    val bitmap = ImageBitmap(tileSize.width, tileSize.height)
+    val canvas = Canvas(bitmap)
+    val sizeF = Size(tileSize.width.toFloat(), tileSize.height.toFloat())
+    val filter = tint?.let { ColorFilter.tint(it, BlendMode.SrcIn) }
+    CanvasDrawScope().draw(
+        density = density,
+        layoutDirection = layoutDirection,
+        canvas = canvas,
+        size = sizeF,
+    ) {
+        with(this@rasterize) { draw(size = sizeF, colorFilter = filter) }
+    }
+    return bitmap
 }
 
 /**

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -92,7 +92,7 @@ import kotlin.math.sqrt
  *
  * **Performance Notes:**
  * - Uses [rememberGraphicsLayer] to render elements efficiently
- * - Pointer input is keyed by [state.mode] to update on mode changes
+ * - Pointer input is keyed by [State.mode] to update on mode changes
  * - [State.bgPattern] is converted to a tiled [ShaderBrush] via [remember];
  *   per-frame work is a single `drawRect` rather than an N×M painter tile loop
  * - Large element lists may impact frame rate; consider implementing virtualization
@@ -259,7 +259,7 @@ private fun Painter.rasterize(
  * Render an element on the canvas based on its type.
  *
  * Dispatches to specific rendering functions:
- * - [Element.Path]: Draws as a continuous stroke using [drawPath]
+ * - [Element.Path]: Draws as a continuous stroke using [DrawScope.drawPath]
  * - [Element.Shape]: Delegates to [drawShape] for type-specific rendering
  *
  * @param element The element to render
@@ -326,7 +326,7 @@ private fun DrawScope.drawShape(shape: Element.Shape) {
             drawRect(
                 color = shape.fillColor ?: shape.strokeColor,
                 topLeft = topLeft,
-                size = androidx.compose.ui.geometry.Size(width, height),
+                size = Size(width, height),
                 style = if (shape.fillColor != null) Fill else Stroke(shape.strokeWidth)
             )
         }

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/BackgroundPattern.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/BackgroundPattern.kt
@@ -1,0 +1,24 @@
+package io.ak1.drawbox.domain.model
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+
+/**
+ * Repeating image painted behind drawing elements, sitting on top of the
+ * solid [State.bgColor] but underneath all strokes and shapes.
+ *
+ * The [painter] is tiled across the canvas at its intrinsic size. Pass an
+ * SVG via `painterResource(...)` for vector tiling that stays sharp at any
+ * zoom level.
+ *
+ * When [tint] is provided, the painter is recolored using
+ * [androidx.compose.ui.graphics.BlendMode.SrcIn] — works well for
+ * monochrome / alpha-driven SVGs. Multi-color SVGs will be collapsed to the
+ * tint color; pass `null` to keep the painter's original colors.
+ *
+ * Not included in JSON/SVG export; treat as a runtime decoration.
+ */
+data class BackgroundPattern(
+    val painter: Painter,
+    val tint: Color? = null,
+)

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
@@ -88,6 +88,15 @@ sealed class Intent {
     data class SetBgColor(val bgColor: Color) : Intent()
 
     /**
+     * Set or clear the repeating background pattern painted above [SetBgColor]
+     * and below all drawing elements.
+     *
+     * Pass `null` to remove an existing pattern. The pattern is purely a runtime
+     * decoration — it is not captured by PNG/JSON/SVG export.
+     */
+    data class SetBackgroundPattern(val pattern: BackgroundPattern?) : Intent()
+
+    /**
      * Switch to a different drawing mode.
      *
      * Changes what type of element is created on the next user interaction.

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
@@ -46,12 +46,15 @@ sealed class Mode {
  * @property strokeColor Color for drawing lines and shape strokes
  * @property strokeWidth Width/thickness of strokes in pixels
  * @property opacity Alpha channel for drawing (0.0 = transparent, 1.0 = opaque)
- * @property bgColor Background color of the canvas
+ * @property bgColor Solid background color of the canvas (painted underneath [bgPattern])
+ * @property bgPattern Optional repeating image tiled above [bgColor] and below all elements;
+ *           runtime decoration only and not persisted by JSON/SVG export
  * @property mode Current drawing mode determining what gets created on user input
  *
  * @see Element
  * @see Intent
  * @see Mode
+ * @see BackgroundPattern
  */
 data class State(
     val elements: List<Element> = emptyList(),
@@ -60,6 +63,7 @@ data class State(
     val strokeWidth: Float = 10f,
     val opacity: Float = 1f,
     val bgColor: Color = Color.Black,
+    val bgPattern: BackgroundPattern? = null,
     val mode: Mode = Mode.PEN,
 ){
     internal var invokeBitmap :(() -> Unit) = {}

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
@@ -97,6 +97,8 @@ class Reducer(
             is Intent.SetStrokeWidth -> state.copy(strokeWidth = intent.width)
             is Intent.SetOpacity -> state.copy(opacity = intent.opacity)
             is Intent.SetBgColor -> state.copy(bgColor = intent.bgColor)
+            // Replaces any existing pattern; null clears it. Layered above bgColor at render time.
+            is Intent.SetBackgroundPattern -> state.copy(bgPattern = intent.pattern)
             is Intent.SetMode -> state.copy(mode = intent.mode)
             is Intent.Undo -> {
                 val (newElements, newUndoStack) = useCase.undo(state.elements, state.undoStack)

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.Painter
+import io.ak1.drawbox.domain.model.BackgroundPattern
 import io.ak1.drawbox.domain.model.PayLoad
 import io.ak1.drawbox.domain.model.DrawingSerializer
 
@@ -176,6 +178,30 @@ class DrawBoxController(
 
     /** Change the canvas background color */
     fun setBgColor(color: Color) = onIntent(Intent.SetBgColor(color))
+
+    /**
+     * Set a repeating image — typically an SVG vector drawable — painted above
+     * the solid [setBgColor] background and below all strokes/shapes.
+     *
+     * The painter is rasterized once at its intrinsic size (64dp square fallback
+     * when no intrinsic size is reported) into a tileable [ImageBitmap], wrapped
+     * in a [ShaderBrush] with [TileMode.Repeated], and reused across recompositions.
+     * Tile work happens once per call, not per frame.
+     *
+     * Pass `null` for [painter] to clear the pattern.
+     *
+     * [tint] recolors the painter via SrcIn blending — ideal for monochrome /
+     * alpha-driven SVGs. Multi-color SVGs and raster-backed assets will be
+     * collapsed to the tint color (every opaque pixel becomes [tint]); pass
+     * `null` to keep the painter's original colors.
+     *
+     * The pattern is a runtime decoration and is intentionally excluded from
+     * PNG / JSON / SVG export.
+     */
+    fun setBackgroundPattern(painter: Painter?, tint: Color? = null) {
+        val pattern = painter?.let { BackgroundPattern(it, tint) }
+        onIntent(Intent.SetBackgroundPattern(pattern))
+    }
 
     /** Switch to a different drawing mode */
     fun setMode(mode: Mode) = onIntent(Intent.SetMode(mode))

--- a/shared/src/commonMain/composeResources/drawable/bg_graph_paper.xml
+++ b/shared/src/commonMain/composeResources/drawable/bg_graph_paper.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+  <path
+      android:pathData="M96,95h4v1h-4v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4h-9v4h-1v-4L0,96v-1h15v-9L0,86v-1h15v-9L0,76v-1h15v-9L0,66v-1h15v-9L0,56v-1h15v-9L0,46v-1h15v-9L0,36v-1h15v-9L0,26v-1h15v-9L0,16v-1h15L15,0h1v15h9L25,0h1v15h9L35,0h1v15h9L45,0h1v15h9L55,0h1v15h9L65,0h1v15h9L75,0h1v15h9L85,0h1v15h9L95,0h1v15h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9h4v1h-4v9zM95,95v-9h-9v9h9zM85,95v-9h-9v9h9zM75,95v-9h-9v9h9zM65,95v-9h-9v9h9zM55,95v-9h-9v9h9zM45,95v-9h-9v9h9zM35,95v-9h-9v9h9zM25,95v-9h-9v9h9zM16,85h9v-9h-9v9zM26,85h9v-9h-9v9zM36,85h9v-9h-9v9zM46,85h9v-9h-9v9zM56,85h9v-9h-9v9zM66,85h9v-9h-9v9zM76,85h9v-9h-9v9zM86,85h9v-9h-9v9zM95,75v-9h-9v9h9zM85,75v-9h-9v9h9zM75,75v-9h-9v9h9zM65,75v-9h-9v9h9zM55,75v-9h-9v9h9zM45,75v-9h-9v9h9zM35,75v-9h-9v9h9zM25,75v-9h-9v9h9zM16,65h9v-9h-9v9zM26,65h9v-9h-9v9zM36,65h9v-9h-9v9zM46,65h9v-9h-9v9zM56,65h9v-9h-9v9zM66,65h9v-9h-9v9zM76,65h9v-9h-9v9zM86,65h9v-9h-9v9zM95,55v-9h-9v9h9zM85,55v-9h-9v9h9zM75,55v-9h-9v9h9zM65,55v-9h-9v9h9zM55,55v-9h-9v9h9zM45,55v-9h-9v9h9zM35,55v-9h-9v9h9zM25,55v-9h-9v9h9zM16,45h9v-9h-9v9zM26,45h9v-9h-9v9zM36,45h9v-9h-9v9zM46,45h9v-9h-9v9zM56,45h9v-9h-9v9zM66,45h9v-9h-9v9zM76,45h9v-9h-9v9zM86,45h9v-9h-9v9zM95,35v-9h-9v9h9zM85,35v-9h-9v9h9zM75,35v-9h-9v9h9zM65,35v-9h-9v9h9zM55,35v-9h-9v9h9zM45,35v-9h-9v9h9zM35,35v-9h-9v9h9zM25,35v-9h-9v9h9zM16,25h9v-9h-9v9zM26,25h9v-9h-9v9zM36,25h9v-9h-9v9zM46,25h9v-9h-9v9zM56,25h9v-9h-9v9zM66,25h9v-9h-9v9zM76,25h9v-9h-9v9zM86,25h9v-9h-9v9z"
+      android:strokeAlpha="0.5"
+      android:fillColor="#000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.5"/>
+  <path
+      android:pathData="M6,5V0H5v5H0v1h5v94h1V6h94V5H6z"
+      android:fillColor="#000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/shared/src/commonMain/composeResources/drawable/bg_hideout.xml
+++ b/shared/src/commonMain/composeResources/drawable/bg_hideout.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M0,38.59l2.83,-2.83 1.41,1.41L1.41,40H0v-1.41zM0,1.4l2.83,2.83 1.41,-1.41L1.41,0H0v1.41zM38.59,40l-2.83,-2.83 1.41,-1.41L40,38.59V40h-1.41zM40,1.41l-2.83,2.83 -1.41,-1.41L38.59,0H40v1.41zM20,18.6l2.83,-2.83 1.41,1.41L21.41,20l2.83,2.83 -1.41,1.41L20,21.41l-2.83,2.83 -1.41,-1.41L18.59,20l-2.83,-2.83 1.41,-1.41L20,18.59z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/shared/src/commonMain/composeResources/drawable/bg_texture.xml
+++ b/shared/src/commonMain/composeResources/drawable/bg_texture.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="4dp"
+    android:viewportWidth="4"
+    android:viewportHeight="4">
+  <path
+      android:pathData="M1,3h1v1L1,4L1,3zM3,1h1v1L3,2L3,1z"
+      android:fillColor="#000000"/>
+</vector>

--- a/shared/src/commonMain/composeResources/drawable/bg_tiny_checkers.xml
+++ b/shared/src/commonMain/composeResources/drawable/bg_tiny_checkers.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="8dp"
+    android:height="8dp"
+    android:viewportWidth="8"
+    android:viewportHeight="8">
+  <path
+      android:pathData="M0,0h4v4L0,4L0,0zM4,4h4v4L4,8L4,4z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -12,9 +12,6 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import drawboxsample.shared.generated.resources.Res
 import drawboxsample.shared.generated.resources.bg_graph_paper
-import drawboxsample.shared.generated.resources.bg_hideout
-import drawboxsample.shared.generated.resources.bg_texture
-import drawboxsample.shared.generated.resources.bg_tiny_checkers
 import io.ak1.drawbox.DrawBox
 import io.ak1.drawbox.domain.model.Event
 import io.ak1.drawbox.presentation.viewmodel.rememberDrawBoxController

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -9,11 +9,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import drawboxsample.shared.generated.resources.Res
+import drawboxsample.shared.generated.resources.bg_graph_paper
+import drawboxsample.shared.generated.resources.bg_hideout
+import drawboxsample.shared.generated.resources.bg_texture
+import drawboxsample.shared.generated.resources.bg_tiny_checkers
 import io.ak1.drawbox.DrawBox
 import io.ak1.drawbox.domain.model.Event
 import io.ak1.drawbox.presentation.viewmodel.rememberDrawBoxController
 import io.ak1.drawboxsample.save.rememberImageSaver
 import io.ak1.drawboxsample.ui.components.ControlsBar
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun HomeScreen() {
@@ -22,7 +29,12 @@ fun HomeScreen() {
     val imageSaver = rememberImageSaver()
 
     // Use DrawBoxController
-    val viewModel = rememberDrawBoxController()
+    val viewModel = rememberDrawBoxController().apply {
+        this.setBackgroundPattern(
+            painter = painterResource(Res.drawable.bg_graph_paper),   // any Painter, including SVG
+            tint    = Color.LightGray.copy(alpha = 0.2f)                           // optional, null keeps original colors
+        )
+    }
     val state by viewModel.state.collectAsState()
     val canUndo by viewModel.canUndo.collectAsState()
     val canRedo by viewModel.canRedo.collectAsState()


### PR DESCRIPTION
  - introduce BackgroundPattern (Painter + optional tint) and thread it
    through State, Intent, Reducer, and DrawBoxController 
  - expose DrawBoxController.setBackgroundPattern(painter, tint)
  - render via a cached ShaderBrush (ImageShader + TileMode.Repeated):
    painter is rasterized once per pattern change with SrcIn tint baked in,
    so per-frame work collapses to a single drawRect — no per-tick re-tile
  - layer order: solid bgColor → tiled pattern → strokes/shapes
  - ship sample vector tiles (bg_graph_paper, bg_hideout, bg_texture,
    bg_tiny_checkers) and wire bg_graph_paper into HomeScreen as a demo
  - runtime-only decoration: excluded from PNG/JSON/SVG export