### PR TITLE
Feat: object eraser tool, replaces pan in controls bar

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -226,13 +226,20 @@ fun DrawBox(
     }
 
     // Cursor: hand in PAN (incl. temp-pan via Space), crosshair for drawing
-    // modes, default otherwise. Picked up by Compose Desktop / Web / IDE
-    // preview; no-op on mobile.
+    // modes, default otherwise. The eraser draws its own circular overlay so
+    // the system cursor is hidden (Default) under it to avoid double-cursoring.
+    // Picked up by Compose Desktop / Web / IDE preview; no-op on mobile.
     val cursor = when (state.effectiveMode) {
         Mode.PAN -> PointerIcon.Hand
         Mode.SELECT -> PointerIcon.Default
+        Mode.ERASER -> PointerIcon.Default
         else -> PointerIcon.Crosshair
     }
+
+    // Live pointer position in WORLD coords for the eraser cursor overlay.
+    // Null when the cursor is outside the canvas or no hover events are
+    // arriving (mobile/touch). The overlay collapses gracefully in that case.
+    var eraserPointerWorld by remember { mutableStateOf<Offset?>(null) }
 
     Box(
         modifier = modifier
@@ -296,6 +303,32 @@ fun DrawBox(
                         val event = awaitPointerEvent(PointerEventPass.Initial)
                         if (event.type == PointerEventType.Press) {
                             runCatching { focusRequester.requestFocus() }
+                        }
+                    }
+                }
+            }
+            // Eraser hover tracking: keep the world-space cursor position fresh
+            // for the eraser overlay circle. Runs as long as the composable is
+            // mounted; the overlay only consumes the value when mode == ERASER.
+            // Touch platforms emit no hover events; the overlay collapses
+            // gracefully in that case.
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        when (event.type) {
+                            PointerEventType.Move,
+                            PointerEventType.Enter,
+                            PointerEventType.Press,
+                            -> {
+                                val pos = event.changes.firstOrNull()?.position
+                                eraserPointerWorld = pos?.let {
+                                    latestState.viewport.screenToWorld(it)
+                                }
+                            }
+                            PointerEventType.Exit -> {
+                                eraserPointerWorld = null
+                            }
                         }
                     }
                 }
@@ -414,6 +447,15 @@ fun DrawBox(
                                 latestOnIntent(Intent.UpdateLatestPath(world))
                             }
                             Mode.PAN -> {} // taps in pan mode are no-ops
+                            Mode.ERASER -> {
+                                // Single tap = atomic erase session. BeginErase
+                                // clears the dirty flag; EraseAt snapshots only
+                                // if it actually removes something. A tap on
+                                // empty space therefore consumes no undo slot.
+                                latestOnIntent(Intent.BeginErase)
+                                latestOnIntent(Intent.EraseAt(world, s.eraserSize / s.viewport.scale))
+                                latestOnIntent(Intent.EndErase)
+                            }
                             else -> modeShapeType(s.effectiveMode)?.let { st ->
                                 latestOnIntent(Intent.InsertNewShape(st, world))
                                 latestOnIntent(Intent.UpdateLatestShape(world))
@@ -473,6 +515,15 @@ fun DrawBox(
                                 latestOnIntent(Intent.InsertNewPath(world))
                                 dragInProgress = true
                             }
+                            Mode.ERASER -> {
+                                // Open the erase gesture: BeginErase clears the
+                                // dirty flag so EraseAt can snapshot lazily on
+                                // the first actual hit. A drag that never
+                                // intersects an element pushes nothing to undo.
+                                latestOnIntent(Intent.BeginErase)
+                                latestOnIntent(Intent.EraseAt(world, s.eraserSize / s.viewport.scale))
+                                dragInProgress = true
+                            }
                             else -> modeShapeType(s.effectiveMode)?.let { st ->
                                 latestOnIntent(Intent.InsertNewShape(st, world))
                                 dragInProgress = true
@@ -502,6 +553,8 @@ fun DrawBox(
                             if (justDrawn is Element.Shape && justDrawn.shapeType == ShapeType.ARROW) {
                                 latestOnIntent(Intent.FinalizeArrowBindings(justDrawn.id))
                             }
+                        } else if (s.mode == Mode.ERASER) {
+                            latestOnIntent(Intent.EndErase)
                         }
                         latestOnIntent(Intent.EndTransform)
                         interaction = null
@@ -512,6 +565,9 @@ fun DrawBox(
                             interaction is SelectionInteraction.Marquee
                         ) {
                             latestOnIntent(Intent.SetMarqueeRect(null))
+                        }
+                        if (latestState.mode == Mode.ERASER) {
+                            latestOnIntent(Intent.EndErase)
                         }
                         latestOnIntent(Intent.EndTransform)
                         interaction = null
@@ -574,6 +630,9 @@ fun DrawBox(
                             else -> {}
                         }
                         Mode.PEN -> latestOnIntent(Intent.UpdateLatestPath(world))
+                        Mode.ERASER -> latestOnIntent(
+                            Intent.EraseAt(world, s.eraserSize / s.viewport.scale),
+                        )
                         else -> if (modeShapeType(s.effectiveMode) != null) {
                             latestOnIntent(Intent.UpdateLatestShape(world))
                         }
@@ -598,6 +657,11 @@ fun DrawBox(
                 when (state.effectiveMode) {
                     Mode.SELECT -> state.selectedIds
                     Mode.PAN -> emptySet()
+                    // The eraser removes elements from the static set on each
+                    // tick. Surviving elements are unchanged, so leave activeIds
+                    // empty and let staticRefsMatch handle the cache rebuild
+                    // when the element list shrinks.
+                    Mode.ERASER -> emptySet()
                     Mode.PEN, Mode.RECTANGLE, Mode.CIRCLE, Mode.TRIANGLE, Mode.ARROW, Mode.LINE -> {
                         val lastId = orderedElements.lastOrNull()?.id
                         if (lastId == null) emptySet() else setOf(lastId)
@@ -651,6 +715,27 @@ fun DrawBox(
                     rotationOffsetPx = rotationOffsetPx,
                     inverseScale = 1f / vp.scale,
                 )
+                // Eraser cursor overlay: outline circle at the world-space
+                // pointer with the configured eraser radius. Drawn inside the
+                // world transform so the radius matches the actual hit area at
+                // any zoom level. Skipped on touch (no hover events → null pos)
+                // and outside ERASER mode.
+                if (state.effectiveMode == Mode.ERASER) {
+                    eraserPointerWorld?.let { center ->
+                        val r = state.eraserSize
+                        val ringColor = if (state.bgColor.luminance() < 0.5f) {
+                            Color.White
+                        } else {
+                            Color.Black
+                        }
+                        drawCircle(
+                            color = ringColor,
+                            radius = r,
+                            center = center,
+                            style = Stroke(width = 1.5f / vp.scale),
+                        )
+                    }
+                }
             }
 
             // On-demand bitmap capture: record the full scene into captureLayer,
@@ -741,7 +826,7 @@ private fun modeShapeType(mode: Mode): ShapeType? = when (mode) {
     Mode.TRIANGLE -> ShapeType.TRIANGLE
     Mode.ARROW -> ShapeType.ARROW
     Mode.LINE -> ShapeType.LINE
-    Mode.PEN, Mode.SELECT, Mode.PAN -> null
+    Mode.PEN, Mode.SELECT, Mode.PAN, Mode.ERASER -> null
 }
 
 // ==================== Selection gesture support ====================

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
@@ -217,6 +217,38 @@ sealed class Intent {
      */
     data class SetSelectedStrokeStyle(val style: StrokeStyle) : Intent()
 
+    // ==================== Eraser Operations ====================
+
+    /**
+     * Open an erase session. Resets [State.erasingSessionDirty] so the next
+     * [EraseAt] that actually removes an element will snapshot history once.
+     * A session that never lands on an element snapshots nothing — taps and
+     * drags through empty space consume no undo slot.
+     *
+     * Not undoable, not history-relevant on its own.
+     */
+    data object BeginErase : Intent()
+
+    /**
+     * Delete every element whose body intersects a disk of [radius] around
+     * [point] (world space). Snapshots history lazily on the first hit within
+     * the current erase session (see [BeginErase]). Subsequent hits inside the
+     * same session mutate elements in place without snapshotting, so a single
+     * undo reverts the entire sweep. No-op when no element is hit — no
+     * snapshot is pushed and no [State] copy is emitted.
+     */
+    data class EraseAt(val point: Offset, val radius: Float) : Intent()
+
+    /**
+     * Close an erase session. Clears [State.erasingSessionDirty] so the next
+     * session starts fresh. Also serves as a transaction-end signal for sync /
+     * autosave observers (see [EndTransform]).
+     */
+    data object EndErase : Intent()
+
+    /** Change the world-space eraser radius used by [Mode.ERASER]. */
+    data class SetEraserSize(val size: Float) : Intent()
+
     /** Move selected elements to the top of the z-order. Snapshots history. */
     data object BringSelectionToFront : Intent()
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.graphics.Color
  * - [LINE]: Creates [Element.Shape] with [ShapeType.LINE]
  * - [SELECT]: Selects existing elements. Tap to select, drag to move, drag a handle
  *   to resize or rotate, drag on empty space to marquee-select multiple elements.
+ * - [ERASER]: Tap or drag to delete elements whose body intersects the eraser
+ *   radius. Whole-element (object) eraser — strokes/shapes are removed atomically.
  *
  * The mode is read from [State.mode] and passed to [DrawBox], which uses it to
  * determine how to interpret user gestures.
@@ -37,6 +39,12 @@ sealed class Mode {
     data object SELECT : Mode()
     /** Pan mode - drag pans the camera; useful for navigating the infinite canvas */
     data object PAN : Mode()
+    /**
+     * Object eraser — tap or drag to delete any element whose body intersects
+     * the eraser radius. Whole-element (not pixel-level): a single hit removes
+     * the entire stroke or shape. Undoable as one gesture.
+     */
+    data object ERASER : Mode()
 }
 
 /**
@@ -92,6 +100,20 @@ data class State(
     val bgColor: Color = Color.Black,
     val bgPattern: BackgroundPattern? = null,
     val mode: Mode = Mode.PEN,
+    /**
+     * World-space radius used by [Mode.ERASER] for hit-testing. Pressure-aware
+     * platforms can modulate this at the gesture layer without persisting the
+     * modulated value here.
+     */
+    val eraserSize: Float = 20f,
+    /**
+     * Within a single erase gesture: has any tick actually removed an element
+     * yet? Used to guarantee at most one history snapshot per gesture, taken
+     * lazily on the first hit. A tap or drag that never intersects an element
+     * therefore consumes no undo slot. Cleared by [Intent.BeginErase] and
+     * [Intent.EndErase]; not persisted.
+     */
+    val erasingSessionDirty: Boolean = false,
 ){
     internal var invokeBitmap :(() -> Unit) = {}
 }

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
@@ -9,6 +9,7 @@ import io.ak1.drawbox.domain.model.ShapeType
 import io.ak1.drawbox.domain.model.StrokeStyle
 import io.ak1.drawbox.domain.model.boundaryPointToward
 import io.ak1.drawbox.domain.model.bounds
+import io.ak1.drawbox.domain.model.hitTest
 import io.ak1.drawbox.domain.model.resizeBounds
 import io.ak1.drawbox.domain.model.topmostHit
 import io.ak1.drawbox.domain.model.touched
@@ -181,6 +182,23 @@ class UseCase {
     /** Delete every element whose id is in `ids`. */
     fun deleteSelected(elements: List<Element>, ids: Set<String>): List<Element> =
         elements.filter { it.id !in ids }
+
+    /**
+     * Remove every element whose body is within `radius` of `point`. Reuses the
+     * same [hitTest] used by selection, with the eraser disk radius substituted
+     * for the pick tolerance — which means stroke width is already accounted
+     * for. Returns the original list instance when nothing was hit so callers
+     * can skip useless state churn.
+     */
+    fun eraseAt(
+        elements: List<Element>,
+        point: Offset,
+        radius: Float,
+    ): List<Element> {
+        if (elements.isEmpty()) return elements
+        val survivors = elements.filterNot { it.hitTest(point, radius) }
+        return if (survivors.size == elements.size) elements else survivors
+    }
 
     /** Promote selected elements to the top of the z-order. */
     fun bringToFront(elements: List<Element>, ids: Set<String>): List<Element> {

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
@@ -165,6 +165,35 @@ class Reducer(
                 ),
             )
         }
+        // Eraser
+        is Intent.BeginErase -> {
+            // Defensive reset: a previous session that was cancelled mid-sweep
+            // without an EndErase would leave the dirty flag stuck.
+            if (state.erasingSessionDirty) state.copy(erasingSessionDirty = false)
+            else state
+        }
+        is Intent.EraseAt -> {
+            // Snapshot lazily on the FIRST removal of the current session — a
+            // tap or drag through empty space pushes nothing to history. The
+            // eraseAt helper returns the same list instance when no element is
+            // hit, so we can detect a miss by reference and short-circuit.
+            val next = useCase.eraseAt(state.elements, intent.point, intent.radius)
+            if (next === state.elements) state
+            else {
+                val base = if (!state.erasingSessionDirty) state.snapshot() else state
+                base.copy(
+                    elements = next,
+                    erasingSessionDirty = true,
+                    selectedIds = state.selectedIds.intersect(next.map { it.id }.toSet()),
+                )
+            }
+        }
+        is Intent.EndErase -> {
+            if (state.erasingSessionDirty) state.copy(erasingSessionDirty = false)
+            else state
+        }
+        is Intent.SetEraserSize -> state.copy(eraserSize = intent.size)
+
         is Intent.BringSelectionToFront -> {
             if (state.selectedIds.isEmpty()) state
             else state.snapshot().copy(

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -250,6 +250,23 @@ class DrawBoxController(
     /** Re-stroke every selected element. */
     fun setSelectionStrokeWidth(width: Float) = onIntent(Intent.SetSelectedStrokeWidth(width))
 
+    /**
+     * Erase every element whose body intersects a disk of [radius] world pixels
+     * around [point]. Snapshots history at most once and only if an element is
+     * actually removed, so calls that hit nothing leave the undo stack
+     * untouched. Useful for programmatic eraser passes; for user-driven
+     * erasing the gesture layer in [io.ak1.drawbox.DrawBox] already drives
+     * this via [Intent.EraseAt] in [Mode.ERASER].
+     */
+    fun eraseAt(point: Offset, radius: Float) {
+        onIntent(Intent.BeginErase)
+        onIntent(Intent.EraseAt(point, radius))
+        onIntent(Intent.EndErase)
+    }
+
+    /** Change the world-space radius used by [Mode.ERASER]. */
+    fun setEraserSize(size: Float) = onIntent(Intent.SetEraserSize(size))
+
     /** Bring selected elements to the top of the z-order. */
     fun bringSelectionToFront() = onIntent(Intent.BringSelectionToFront)
 

--- a/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/domain/usecase/DrawingUseCaseTest.kt
+++ b/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/domain/usecase/DrawingUseCaseTest.kt
@@ -6,6 +6,7 @@ import io.ak1.drawbox.domain.model.Element
 import io.ak1.drawbox.domain.model.ShapeType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class UseCaseTest {
@@ -115,6 +116,60 @@ class UseCaseTest {
         assertEquals(ShapeType.RECTANGLE, result.shapeType)
         assertEquals(offset, result.points[0])
         assertEquals(color, result.strokeColor)
+    }
+
+    @Test
+    fun testEraseAtRemovesPathInRadius() {
+        val path = Element.Path(
+            points = listOf(Offset(0f, 0f), Offset(100f, 0f)),
+            strokeColor = Color.Red,
+            strokeWidth = 4f,
+            alpha = 1f,
+        )
+        val elements = useCase.addElement(path, emptyList())
+
+        val result = useCase.eraseAt(elements, Offset(50f, 0f), radius = 5f)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun testEraseAtMissReturnsSameInstance() {
+        val path = Element.Path(
+            points = listOf(Offset(0f, 0f), Offset(100f, 0f)),
+            strokeColor = Color.Red,
+            strokeWidth = 1f,
+            alpha = 1f,
+        )
+        val elements = useCase.addElement(path, emptyList())
+
+        // Far away from the path: nothing hit. Reducer relies on this
+        // identity contract to skip no-op state copies.
+        val result = useCase.eraseAt(elements, Offset(500f, 500f), radius = 5f)
+
+        assertSame(elements, result)
+    }
+
+    @Test
+    fun testEraseAtPreservesUnhitElements() {
+        val hit = Element.Path(
+            points = listOf(Offset(0f, 0f), Offset(50f, 0f)),
+            strokeColor = Color.Red,
+            strokeWidth = 2f,
+            alpha = 1f,
+        )
+        val miss = Element.Path(
+            points = listOf(Offset(0f, 200f), Offset(50f, 200f)),
+            strokeColor = Color.Blue,
+            strokeWidth = 2f,
+            alpha = 1f,
+        )
+        val elements = useCase.addElement(miss, useCase.addElement(hit, emptyList()))
+
+        val result = useCase.eraseAt(elements, Offset(25f, 0f), radius = 5f)
+
+        assertEquals(1, result.size)
+        assertEquals(miss.id, result[0].id)
     }
 
 }

--- a/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/presentation/reducer/DrawingReducerTest.kt
+++ b/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/presentation/reducer/DrawingReducerTest.kt
@@ -176,4 +176,63 @@ class DrawingReducerTest {
         assertTrue(newState.future.isEmpty())
         assertEquals(1, newState.history.size)
     }
+
+    // ===== Eraser =====
+
+    private fun erasablePath(): Element.Path = Element.Path(
+        points = listOf(Offset(0f, 0f), Offset(100f, 0f)),
+        strokeColor = Color.Red,
+        strokeWidth = 4f,
+        alpha = 1f,
+    )
+
+    @Test
+    fun testEraseAtOnEmptySpaceLeavesHistoryAlone() {
+        val path = erasablePath()
+        val initial = State(elements = listOf(path))
+
+        var s = reducer.reduce(initial, Intent.BeginErase)
+        // Tap far away from the path: no element is hit.
+        s = reducer.reduce(s, Intent.EraseAt(Offset(500f, 500f), radius = 5f))
+        s = reducer.reduce(s, Intent.EndErase)
+
+        assertEquals(1, s.elements.size)
+        assertTrue(s.history.isEmpty(), "no element hit → no history entry")
+        assertTrue(!s.erasingSessionDirty, "session should be closed cleanly")
+    }
+
+    @Test
+    fun testEraseAtFirstHitSnapshotsHistoryOnce() {
+        val a = erasablePath().copy(id = "a")
+        val b = erasablePath().copy(
+            id = "b",
+            points = listOf(Offset(0f, 200f), Offset(100f, 200f)),
+        )
+        val initial = State(elements = listOf(a, b))
+
+        var s = reducer.reduce(initial, Intent.BeginErase)
+        // Three EraseAt ticks within one gesture, each landing on a different
+        // element after a miss. Only the first hit should snapshot.
+        s = reducer.reduce(s, Intent.EraseAt(Offset(500f, 500f), 5f))   // miss
+        s = reducer.reduce(s, Intent.EraseAt(Offset(50f, 0f), 5f))      // hit a
+        s = reducer.reduce(s, Intent.EraseAt(Offset(50f, 200f), 5f))    // hit b
+        s = reducer.reduce(s, Intent.EndErase)
+
+        assertEquals(0, s.elements.size)
+        assertEquals(1, s.history.size, "single snapshot covers the whole sweep")
+        // Undoing the gesture restores both elements as one operation.
+        val undone = reducer.reduce(s, Intent.Undo)
+        assertEquals(2, undone.elements.size)
+    }
+
+    @Test
+    fun testEraseAtSetsSessionDirtyOnlyAfterHit() {
+        val initial = State(elements = listOf(erasablePath()))
+        val opened = reducer.reduce(initial, Intent.BeginErase)
+        val missed = reducer.reduce(opened, Intent.EraseAt(Offset(500f, 500f), 5f))
+        assertTrue(!missed.erasingSessionDirty)
+
+        val hit = reducer.reduce(missed, Intent.EraseAt(Offset(50f, 0f), 5f))
+        assertTrue(hit.erasingSessionDirty)
+    }
 }

--- a/shared/src/commonMain/composeResources/drawable/eraser.xml
+++ b/shared/src/commonMain/composeResources/drawable/eraser.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16.95,3.46l3.59,3.59a2,2 0,0 1,0 2.83l-9.9,9.9h-6.43l-2.83,-2.83a2,2 0,0 1,0 -2.83l12.74,-12.74a2,2 0,0 1,2.83 0z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M7.5,7.5l9,9"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ControlsBar.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ControlsBar.kt
@@ -26,12 +26,17 @@ import org.jetbrains.compose.resources.painterResource
 /**
  * Bottom-center floating tool bar. Six slots, left → right:
  *
- *   [Undo] [Redo] [Select] [Pan] [Pen] [Shape▾]
+ *   [Undo] [Redo] [Select] [Eraser] [Pen] [Shape▾]
  *
- * Pen (freehand) and Pan get their own slots so the dropdown is purely shape
- * tools. The currently active tool — whether Select, Pan, Pen, or a shape —
- * is tinted with the primary color so the user can tell at a glance which
- * mode they're in.
+ * Pen (freehand) and Eraser get their own slots so the dropdown is purely
+ * shape tools. The currently active tool — whether Select, Eraser, Pen, or a
+ * shape — is tinted with the primary color so the user can tell at a glance
+ * which mode they're in.
+ *
+ * Pan is intentionally absent from the toolbar: panning is still always
+ * available via Space-bar (hold to temp-pan), middle-mouse drag, two-finger
+ * touch, and the scroll wheel. Removing it from the bar reclaims the slot for
+ * the eraser, which is a far more common drawing-tool action.
  *
  * Color / stroke width / stroke style / corner radius live in the contextual
  * top-right [ContextBar] for the active drawing mode or selection. File /
@@ -116,16 +121,16 @@ fun ControlsBar(
             onClick = { onModeSelected(Mode.SELECT) },
         ),
         FloatingMenuItem(
-            id = "pan",
-            isActive = currentMode == Mode.PAN,
+            id = "eraser",
+            isActive = currentMode == Mode.ERASER,
             icon = { isActive ->
                 Icon(
-                    painter = painterResource(DrawBoxIcons.Hand),
-                    contentDescription = "Pan",
+                    painter = painterResource(DrawBoxIcons.Eraser),
+                    contentDescription = "Eraser",
                     tint = isActive.getActiveColor(),
                 )
             },
-            onClick = { onModeSelected(Mode.PAN) },
+            onClick = { onModeSelected(Mode.ERASER) },
         ),
         FloatingMenuItem(
             id = "pen",

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/icons/DrawBoxIcons.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/icons/DrawBoxIcons.kt
@@ -8,6 +8,7 @@ import drawboxsample.shared.generated.resources.border_corner_square
 import drawboxsample.shared.generated.resources.circle
 import drawboxsample.shared.generated.resources.curved
 import drawboxsample.shared.generated.resources.dots_vertical
+import drawboxsample.shared.generated.resources.eraser
 import drawboxsample.shared.generated.resources.export
 import drawboxsample.shared.generated.resources.file_import
 import drawboxsample.shared.generated.resources.file_type_svg
@@ -37,6 +38,7 @@ object DrawBoxIcons {
     val Sketch: DrawableResource = Res.drawable.sketching
     val Trash: DrawableResource = Res.drawable.trash
     val Hand: DrawableResource = Res.drawable.hand_stop
+    val Eraser: DrawableResource = Res.drawable.eraser
 
     val BorderPill: DrawableResource = Res.drawable.border_corner_pill
     val BorderRounded: DrawableResource = Res.drawable.border_corner_rounded


### PR DESCRIPTION
- Mode.ERASER with tap-to-erase and drag-to-sweep
- stroke-width-aware hit detection via Element.hitTest
- lazy history snapshot: pushed only on the first actual removal per gesture, so empty-space taps and drags consume no undo slot
- world-space cursor ring scales with zoom; auto-contrast on bg
- new eraser.xml drawable + DrawBoxIcons.Eraser
- pan capability preserved via space-bar, middle-mouse drag, two-finger touch, and scroll wheel — only the toolbar slot moves
- controller exposes eraseAt() and setEraserSize()