### PR TITLE
feat: connector endpoints snap to facing side midpoint, rotation-aware

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Geometry.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Geometry.kt
@@ -69,6 +69,92 @@ fun Element.Shape.bezierMidpoint(): Offset {
 }
 
 /**
+ * World-space attachment point for an arrow connector binding to this shape.
+ *
+ * Snaps to the **center of the side that faces [target]**, instead of letting
+ * the connector slide along the outline:
+ *
+ * - **Rectangle / square / fallback**: midpoint of whichever of the four
+ *   AABB edges faces [target].
+ * - **Triangle**: midpoint of whichever of the three edges (right slant,
+ *   bottom, left slant) the ray from the centroid toward [target] crosses.
+ * - **Circle**: tangent point on the circle in [target]'s direction. Circles
+ *   have no sides, so a smooth analytic point is the natural anchor.
+ *
+ * Rotation-aware. The shape's `rotation` is undone on [target], the anchor
+ * is computed in the unrotated frame, then rotated back to world. Scale is
+ * automatically handled because [bounds] reflects the post-scale points.
+ *
+ * Used by `propagateBindings` and `finalizeArrowBindings` so a bound arrow
+ * rides the bound shape's facing side through move / resize / rotate.
+ */
+fun Element.Shape.connectorAnchor(target: Offset): Offset {
+    val b = bounds()
+    val pivot = b.center
+    val localTarget = if (rotation == 0f) target
+                      else rotateAround(target, pivot, -rotation)
+    val localAnchor: Offset = when (shapeType) {
+        ShapeType.CIRCLE -> circleBoundary(pivot, b.width * 0.5f, localTarget)
+        ShapeType.TRIANGLE -> triangleSideMidpoint(b, localTarget)
+        else -> rectSideMidpoint(b, localTarget)
+    }
+    return if (rotation == 0f) localAnchor
+           else rotateAround(localAnchor, pivot, rotation)
+}
+
+/**
+ * Midpoint of whichever AABB side faces [target]. The "facing" axis is the
+ * one along which [target] escapes the box first — i.e. the larger of
+ * `|dx|/halfW` vs `|dy|/halfH`.
+ */
+private fun rectSideMidpoint(bounds: Rect, target: Offset): Offset {
+    val center = bounds.center
+    val halfW = bounds.width * 0.5f
+    val halfH = bounds.height * 0.5f
+    val dx = target.x - center.x
+    val dy = target.y - center.y
+    if (dx == 0f && dy == 0f) return Offset(bounds.right, center.y)
+    val fx = if (halfW > 0f) abs(dx) / halfW else Float.MAX_VALUE
+    val fy = if (halfH > 0f) abs(dy) / halfH else Float.MAX_VALUE
+    return if (fx >= fy) {
+        Offset(if (dx > 0f) bounds.right else bounds.left, center.y)
+    } else {
+        Offset(center.x, if (dy > 0f) bounds.bottom else bounds.top)
+    }
+}
+
+/**
+ * Midpoint of whichever triangle edge the ray from the centroid toward
+ * [target] crosses first. Uses the same edge order as [triangleBoundary]
+ * and shares [raySegmentParam] for the intersection math.
+ */
+private fun triangleSideMidpoint(bounds: Rect, target: Offset): Offset {
+    val apex = Offset(bounds.center.x, bounds.top)
+    val br = Offset(bounds.right, bounds.bottom)
+    val bl = Offset(bounds.left, bounds.bottom)
+    val origin = Offset(bounds.center.x, (bounds.top + 2f * bounds.bottom) / 3f)
+    val dx = target.x - origin.x
+    val dy = target.y - origin.y
+    if (dx == 0f && dy == 0f) {
+        return Offset((apex.x + br.x) * 0.5f, (apex.y + br.y) * 0.5f)
+    }
+    val edges = arrayOf(apex to br, br to bl, bl to apex)
+    var bestT = Float.MAX_VALUE
+    var hitEdge = edges[0]
+    for (edge in edges) {
+        val t = raySegmentParam(origin, dx, dy, edge.first, edge.second) ?: continue
+        if (t > 0f && t < bestT) {
+            bestT = t
+            hitEdge = edge
+        }
+    }
+    return Offset(
+        (hitEdge.first.x + hitEdge.second.x) * 0.5f,
+        (hitEdge.first.y + hitEdge.second.y) * 0.5f,
+    )
+}
+
+/**
  * Point on this shape's outline closest to the ray from the shape's center
  * toward [target]. Used by arrow connectors to terminate at the boundary
  * instead of sinking into the shape.
@@ -77,6 +163,9 @@ fun Element.Shape.bezierMidpoint(): Offset {
  * - Triangle: ray intersected against the three actual edges; the slanted
  *   sides return a point on the slant, not the AABB.
  * - Rectangle / fallback: AABB boundary along the ray.
+ *
+ * Note: this slides along the outline. For connector binding, prefer
+ * [connectorAnchor] which snaps to side midpoints and respects rotation.
  */
 fun Element.Shape.boundaryPointToward(target: Offset): Offset {
     val b = bounds()

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
@@ -7,8 +7,8 @@ import io.ak1.drawbox.domain.model.Element
 import io.ak1.drawbox.domain.model.ResizeHandle
 import io.ak1.drawbox.domain.model.ShapeType
 import io.ak1.drawbox.domain.model.StrokeStyle
-import io.ak1.drawbox.domain.model.boundaryPointToward
 import io.ak1.drawbox.domain.model.bounds
+import io.ak1.drawbox.domain.model.connectorAnchor
 import io.ak1.drawbox.domain.model.hitTest
 import io.ak1.drawbox.domain.model.resizeBounds
 import io.ak1.drawbox.domain.model.topmostHit
@@ -348,8 +348,8 @@ class UseCase {
             // the boundary — the curve would bulge way past the visible line.
             val startShape = candidates.first { it.id == startId }
             val endShape = candidates.first { it.id == endId }
-            val startSnapped = startShape.boundaryPointToward(endShape.bounds().center)
-            val endSnapped = endShape.boundaryPointToward(startShape.bounds().center)
+            val startSnapped = startShape.connectorAnchor(endShape.bounds().center)
+            val endSnapped = endShape.connectorAnchor(startShape.bounds().center)
             defaultConnectorBend(startSnapped, endSnapped)
         } else target.bend
 
@@ -384,8 +384,8 @@ class UseCase {
             // reference point so the arrow visually starts/ends at the edge.
             val endRef = endTarget?.bounds()?.center ?: el.points.last()
             val startRef = startTarget?.bounds()?.center ?: el.points[0]
-            val newStart = startTarget?.boundaryPointToward(endRef) ?: el.points[0]
-            val newEnd = endTarget?.boundaryPointToward(startRef) ?: el.points.last()
+            val newStart = startTarget?.connectorAnchor(endRef) ?: el.points[0]
+            val newEnd = endTarget?.connectorAnchor(startRef) ?: el.points.last()
             val newStartBinding = if (startTarget == null) null else el.startBinding
             val newEndBinding = if (endTarget == null) null else el.endBinding
             // Skip touching the arrow when nothing actually changed — propagateBindings

--- a/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/domain/model/GeometryTest.kt
+++ b/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/domain/model/GeometryTest.kt
@@ -299,6 +299,128 @@ class GeometryTest {
             "exit (${hit.x}, ${hit.y}) not on slant (expected y≈$expectedY)")
     }
 
+    // ============ connectorAnchor ============
+
+    private fun assertOffsetEquals(
+        expected: Offset, actual: Offset, eps: Float = 0.5f,
+    ) {
+        assertTrue(abs(expected.x - actual.x) < eps,
+            "x ${actual.x} != ${expected.x}")
+        assertTrue(abs(expected.y - actual.y) < eps,
+            "y ${actual.y} != ${expected.y}")
+    }
+
+    @Test
+    fun connectorAnchorRectangleEastTargetSnapsToRightMidpoint() {
+        // Rect (0,0)-(100,60), center (50,30). Target far to the east.
+        val rect = rectShape(0f, 0f, 100f, 60f)
+        val anchor = rect.connectorAnchor(Offset(1000f, 30f))
+        assertOffsetEquals(Offset(100f, 30f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorRectangleNorthTargetSnapsToTopMidpoint() {
+        val rect = rectShape(0f, 0f, 100f, 60f)
+        val anchor = rect.connectorAnchor(Offset(50f, -1000f))
+        assertOffsetEquals(Offset(50f, 0f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorRectangleSouthwestTargetSnapsToBottomOrLeft() {
+        // 100×60 rect. Target at (-50, 100): dx=-100, dy=70.
+        // |dx|/50 = 2.0, |dy|/30 ≈ 2.33 → fy > fx → bottom side.
+        val rect = rectShape(0f, 0f, 100f, 60f)
+        val anchor = rect.connectorAnchor(Offset(-50f, 100f))
+        assertOffsetEquals(Offset(50f, 60f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorTriangleEastTargetSnapsToRightSlantMidpoint() {
+        val triangle = Element.Shape(
+            shapeType = ShapeType.TRIANGLE,
+            points = listOf(Offset(0f, 0f), Offset(100f, 100f)),
+            strokeColor = Color.Red,
+            strokeWidth = 4f,
+        )
+        // Apex (50,0), br (100,100), bl (0,100). Right slant midpoint = (75, 50).
+        val anchor = triangle.connectorAnchor(Offset(500f, 50f))
+        assertOffsetEquals(Offset(75f, 50f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorTriangleSouthTargetSnapsToBottomMidpoint() {
+        val triangle = Element.Shape(
+            shapeType = ShapeType.TRIANGLE,
+            points = listOf(Offset(0f, 0f), Offset(100f, 100f)),
+            strokeColor = Color.Red,
+            strokeWidth = 4f,
+        )
+        // Bottom edge midpoint = (50, 100).
+        val anchor = triangle.connectorAnchor(Offset(50f, 500f))
+        assertOffsetEquals(Offset(50f, 100f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorCirclePreservesTangentBehavior() {
+        // Circle points are diameter endpoints. Use a horizontal diameter so
+        // radius is unambiguously 50 and bounds = (0,0)..(100,100).
+        val circle = Element.Shape(
+            shapeType = ShapeType.CIRCLE,
+            points = listOf(Offset(0f, 50f), Offset(100f, 50f)),
+            strokeColor = Color.Red,
+            strokeWidth = 4f,
+        )
+        // Target due east → tangent at (100, 50).
+        val anchor = circle.connectorAnchor(Offset(1000f, 50f))
+        assertOffsetEquals(Offset(100f, 50f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorRotatedRectangleTracksTheRotatedFacingSide() {
+        // 100×60 rect rotated 90° CCW around its center (50, 30).
+        // In world coordinates the visual top-facing side after rotation is
+        // the local LEFT side; the world right-facing side is the local TOP.
+        val rect = Element.Shape(
+            shapeType = ShapeType.RECTANGLE,
+            points = listOf(Offset(0f, 0f), Offset(100f, 60f)),
+            strokeColor = Color.Red,
+            strokeWidth = 4f,
+            rotation = 90f,
+        )
+        // Target due east in world (relative to center (50, 30)).
+        val anchor = rect.connectorAnchor(Offset(500f, 30f))
+        // Local top-midpoint (50, 0) rotated 90° CCW around (50, 30):
+        //   delta from pivot = (0, -30) → rotated = (30, 0) → +pivot = (80, 30).
+        assertOffsetEquals(Offset(80f, 30f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorRotatedRectangleNorthTargetMapsToLocalLeft() {
+        val rect = Element.Shape(
+            shapeType = ShapeType.RECTANGLE,
+            points = listOf(Offset(0f, 0f), Offset(100f, 60f)),
+            strokeColor = Color.Red,
+            strokeWidth = 4f,
+            rotation = 90f,
+        )
+        // Target due north in world (50, -1000). Pivot (50, 30).
+        // localTarget = rotate(target, pivot, -90°). delta (0, -1030).
+        //   With θ=-90°: (dx*c - dy*s, dx*s + dy*c) = (0 - 1030, 0 + 0)
+        //   → (-1030, 0). +pivot = (-980, 30). Local target is due WEST.
+        // Rect local left midpoint = (0, 30). After rotating back:
+        //   delta (-50, 0). θ=90°: (0 - 0, -50 + 0) = (0, -50). +pivot = (50, -20).
+        val anchor = rect.connectorAnchor(Offset(50f, -1000f))
+        assertOffsetEquals(Offset(50f, -20f), anchor)
+    }
+
+    @Test
+    fun connectorAnchorScalesWithRectangle() {
+        // Same rect resized larger — the anchor must scale with it.
+        val rect = rectShape(0f, 0f, 200f, 80f)
+        val anchor = rect.connectorAnchor(Offset(1000f, 40f))
+        assertOffsetEquals(Offset(200f, 40f), anchor)
+    }
+
     @Test
     fun resizeBoundsKeepsOppositeCornerFixedUnderRotation() {
         // 90° rotation of a 100×100 unit at the origin. The TopLeft corner


### PR DESCRIPTION
  - New Element.Shape.connectorAnchor(target) returns the midpoint of whichever rect/triangle side faces the target, or the analytic tangent for circles.
  - Anchor is computed in the shape's local (unrotated) frame and rotated back to world, so bound arrows track the bound shape's facing side through move / resize / rotate.
  - propagateBindings and finalizeArrowBindings switched over; boundaryPointToward left in place for non-binding callers.
  - 9 GeometryTest cases: rect (east / north / southwest), triangle (east / south), circle (tangent), rotated rect (east / north), scaled rect.

  Closes #69
  Closes #70