### PR TITLE
feat: independent fill + stroke for shapes (closes #77)

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -1333,9 +1333,12 @@ private fun DrawScope.drawImageElement(image: Element.Image, imageCache: ImageBi
  * - width: absolute difference in x coordinates
  * - height: absolute difference in y coordinates
  *
- * **Fill vs Stroke:**
- * - If [Element.Shape.fillColor] is set: shape is filled
- * - If null: shape is stroked with [Element.Shape.strokeColor]
+ * **Fill and stroke (independent):**
+ * - If [Element.Shape.fillColor] is set, a fill pass is drawn with that color.
+ * - If [Element.Shape.strokeEnabled] is true AND [Element.Shape.strokeWidth] > 0,
+ *   a stroke pass is drawn on top with [Element.Shape.strokeColor].
+ * - Both can be on (filled with a colored border), either alone, or — for an
+ *   invisible shape — neither.
  *
  * @param shape The shape element to render
  *
@@ -1355,25 +1358,48 @@ private fun DrawScope.drawShape(shape: Element.Shape) {
         minOf(start.x, end.x),
         minOf(start.y, end.y)
     )
+    val hasFill = shape.fillColor != null
+    val hasStroke = shape.strokeEnabled && shape.strokeWidth > 0f
 
     when (shape.shapeType) {
         ShapeType.RECTANGLE -> {
             val r = shape.cornerRadius.coerceAtMost(minOf(width, height) * 0.5f)
-            if (r > 0f) {
-                drawRoundRect(
-                    color = shape.fillColor ?: shape.strokeColor,
-                    topLeft = topLeft,
-                    size = Size(width, height),
-                    cornerRadius = CornerRadius(r, r),
-                    style = shape.drawStyle(),
-                )
-            } else {
-                drawRect(
-                    color = shape.fillColor ?: shape.strokeColor,
-                    topLeft = topLeft,
-                    size = Size(width, height),
-                    style = shape.drawStyle(),
-                )
+            val size = Size(width, height)
+            if (hasFill) {
+                if (r > 0f) {
+                    drawRoundRect(
+                        color = shape.fillColor!!,
+                        topLeft = topLeft,
+                        size = size,
+                        cornerRadius = CornerRadius(r, r),
+                        style = Fill,
+                    )
+                } else {
+                    drawRect(
+                        color = shape.fillColor!!,
+                        topLeft = topLeft,
+                        size = size,
+                        style = Fill,
+                    )
+                }
+            }
+            if (hasStroke) {
+                if (r > 0f) {
+                    drawRoundRect(
+                        color = shape.strokeColor,
+                        topLeft = topLeft,
+                        size = size,
+                        cornerRadius = CornerRadius(r, r),
+                        style = shape.strokeDrawStyle(),
+                    )
+                } else {
+                    drawRect(
+                        color = shape.strokeColor,
+                        topLeft = topLeft,
+                        size = size,
+                        style = shape.strokeDrawStyle(),
+                    )
+                }
             }
         }
         ShapeType.CIRCLE -> {
@@ -1383,12 +1409,22 @@ private fun DrawScope.drawShape(shape: Element.Shape) {
             )
             val distance = sqrt((end.x - start.x) * (end.x - start.x) + (end.y - start.y) * (end.y - start.y))
             val radius = distance / 2
-            drawCircle(
-                color = shape.fillColor ?: shape.strokeColor,
-                radius = radius,
-                center = center,
-                style = shape.drawStyle(),
-            )
+            if (hasFill) {
+                drawCircle(
+                    color = shape.fillColor!!,
+                    radius = radius,
+                    center = center,
+                    style = Fill,
+                )
+            }
+            if (hasStroke) {
+                drawCircle(
+                    color = shape.strokeColor,
+                    radius = radius,
+                    center = center,
+                    style = shape.strokeDrawStyle(),
+                )
+            }
         }
         ShapeType.TRIANGLE -> {
             drawTriangle(topLeft, width, height, shape)
@@ -1427,9 +1463,13 @@ private fun DrawScope.drawShape(shape: Element.Shape) {
     }
 }
 
-/** Stroke/fill style for an [Element.Shape] respecting its [StrokeStyle]. */
-private fun Element.Shape.drawStyle(): androidx.compose.ui.graphics.drawscope.DrawStyle =
-    if (fillColor != null) Fill else Stroke(
+/**
+ * The Stroke style for an [Element.Shape] respecting its [StrokeStyle]. Always
+ * returns a Stroke — fill is drawn as a separate pass in [drawShape] so a
+ * shape can carry both a fill color and an outline.
+ */
+private fun Element.Shape.strokeDrawStyle(): androidx.compose.ui.graphics.drawscope.DrawStyle =
+    Stroke(
         width = strokeWidth,
         cap = strokeCapFor(strokeStyle),
         join = StrokeJoin.Round,
@@ -1641,11 +1681,12 @@ private fun DrawScope.drawTriangle(
             close()
         }
     }
-    drawPath(
-        path,
-        color = shape.fillColor ?: shape.strokeColor,
-        style = shape.drawStyle(),
-    )
+    if (shape.fillColor != null) {
+        drawPath(path, color = shape.fillColor, style = Fill)
+    }
+    if (shape.strokeEnabled && shape.strokeWidth > 0f) {
+        drawPath(path, color = shape.strokeColor, style = shape.strokeDrawStyle())
+    }
 }
 
 /**

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Element.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Element.kt
@@ -206,6 +206,7 @@ sealed class Element {
         val points: List<Offset>,
         val strokeColor: Color,
         val fillColor: Color? = null,
+        val strokeEnabled: Boolean = true,
         val strokeWidth: Float,
         override val zIndex: Int = 0,
         override val rotation: Float = 0f,

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
@@ -243,6 +243,20 @@ sealed class Intent {
     /** Replace the stroke color of every selected element. Snapshots history. */
     data class SetSelectedStrokeColor(val color: Color) : Intent()
 
+    /**
+     * Replace the fill color of every selected [Element.Shape]. Pass `null` to
+     * clear the fill so the shape renders stroke-only. Paths and images in the
+     * selection are left untouched. Snapshots history.
+     */
+    data class SetSelectedFillColor(val color: Color?) : Intent()
+
+    /**
+     * Toggle the stroke pass on every selected [Element.Shape]. `false` makes
+     * the shape fill-only; `true` restores the outline. Paths and images
+     * (always stroked) are left untouched. Snapshots history.
+     */
+    data class SetSelectedStrokeEnabled(val enabled: Boolean) : Intent()
+
     /** Replace the stroke width of every selected element. Snapshots history. */
     data class SetSelectedStrokeWidth(val width: Float) : Intent()
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Serialization.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Serialization.kt
@@ -142,6 +142,12 @@ data class ElementDto(
      */
     val samples: List<String>? = null,
     /**
+     * Tri-state Shape stroke toggle. `null` (omitted) and `true` both mean
+     * "draw stroke" so legacy exports keep rendering; `false` skips the
+     * stroke pass entirely (fill-only shapes).
+     */
+    val strokeEnabled: Boolean? = null,
+    /**
      * Raw encoded image payload, base64-encoded. Only set for Image
      * elements. Inline (rather than external reference) so the JSON file
      * round-trips as a single artifact.
@@ -204,6 +210,7 @@ fun Element.toDto(): ElementDto = when (this) {
         endBinding = endBinding,
         createdAt = createdAt.takeIf { it != 0L },
         modifiedAt = modifiedAt.takeIf { it != 0L },
+        strokeEnabled = false.takeIf { !strokeEnabled },
     )
 }
 
@@ -244,6 +251,7 @@ fun ElementDto.toElement(): Element = when (type) {
         points = points.map { it.toOffset() },
         strokeColor = strokeColor.toColor(),
         fillColor = fillColor?.toColor(),
+        strokeEnabled = strokeEnabled ?: true,
         strokeWidth = strokeWidth,
         zIndex = zIndex,
         rotation = rotation ?: 0f,
@@ -305,6 +313,7 @@ data class SerializableElement(
     val createdAt: Long? = null,
     val modifiedAt: Long? = null,
     val samples: List<String>? = null,
+    val strokeEnabled: Boolean? = null,
     val imageData: String? = null,
     val intrinsicWidth: Float? = null,
     val intrinsicHeight: Float? = null,
@@ -344,6 +353,7 @@ object DrawingSerializer {
                     createdAt = element.createdAt,
                     modifiedAt = element.modifiedAt,
                     samples = element.samples,
+                    strokeEnabled = element.strokeEnabled,
                     imageData = element.imageData,
                     intrinsicWidth = element.intrinsicWidth,
                     intrinsicHeight = element.intrinsicHeight,
@@ -378,6 +388,7 @@ object DrawingSerializer {
                     createdAt = element.createdAt,
                     modifiedAt = element.modifiedAt,
                     samples = element.samples,
+                    strokeEnabled = element.strokeEnabled,
                     imageData = element.imageData,
                     intrinsicWidth = element.intrinsicWidth,
                     intrinsicHeight = element.intrinsicHeight,

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/SvgExporter.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/SvgExporter.kt
@@ -161,8 +161,9 @@ object SvgExporter {
 
         val start = shape.points[0]
         val end = shape.points[1]
-        val color = colorToHex(shape.strokeColor)
-        val strokeWidth = shape.strokeWidth
+        val strokeOn = shape.strokeEnabled && shape.strokeWidth > 0f
+        val color = if (strokeOn) colorToHex(shape.strokeColor) else "none"
+        val strokeWidth = if (strokeOn) shape.strokeWidth else 0f
         val fillColor = if (shape.fillColor != null) colorToHex(shape.fillColor) else "none"
         val fillAttr = if (shape.fillColor != null) """fill="$fillColor"""" else """fill="none""""
 
@@ -170,8 +171,8 @@ object SvgExporter {
             ShapeType.RECTANGLE -> rectangleToSvg(start, end, color, strokeWidth, fillAttr)
             ShapeType.CIRCLE -> circleToSvg(start, end, color, strokeWidth, fillAttr)
             ShapeType.TRIANGLE -> triangleToSvg(start, end, color, strokeWidth, fillAttr)
-            ShapeType.ARROW -> arrowToSvg(start, end, color, strokeWidth)
-            ShapeType.LINE -> lineToSvg(start, end, color, strokeWidth)
+            ShapeType.ARROW -> arrowToSvg(start, end, colorToHex(shape.strokeColor), shape.strokeWidth)
+            ShapeType.LINE -> lineToSvg(start, end, colorToHex(shape.strokeColor), shape.strokeWidth)
         }
     }
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
@@ -304,6 +304,39 @@ class UseCase {
         }
     }
 
+    /**
+     * Set the fill color of every selected shape. `null` clears the fill so the
+     * shape renders stroke-only. Paths and images have no fill concept and are
+     * left untouched — multi-selecting a mix still works.
+     */
+    fun setSelectedFillColor(
+        elements: List<Element>,
+        ids: Set<String>,
+        color: Color?,
+    ): List<Element> = elements.map { el ->
+        if (el.id !in ids) el else when (el) {
+            is Element.Shape -> el.copy(fillColor = color).touched()
+            is Element.Path -> el
+            is Element.Image -> el
+        }
+    }
+
+    /**
+     * Toggle the stroke pass on every selected shape. Paths are always
+     * stroked, so they're left untouched.
+     */
+    fun setSelectedStrokeEnabled(
+        elements: List<Element>,
+        ids: Set<String>,
+        enabled: Boolean,
+    ): List<Element> = elements.map { el ->
+        if (el.id !in ids) el else when (el) {
+            is Element.Shape -> el.copy(strokeEnabled = enabled).touched()
+            is Element.Path -> el
+            is Element.Image -> el
+        }
+    }
+
     /** Re-stroke every selected element. */
     fun setSelectedStrokeWidth(
         elements: List<Element>,

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
@@ -153,6 +153,22 @@ class Reducer(
                 ),
             )
         }
+        is Intent.SetSelectedFillColor -> {
+            if (state.selectedIds.isEmpty()) state
+            else state.snapshot().copy(
+                elements = useCase.setSelectedFillColor(
+                    state.elements, state.selectedIds, intent.color,
+                ),
+            )
+        }
+        is Intent.SetSelectedStrokeEnabled -> {
+            if (state.selectedIds.isEmpty()) state
+            else state.snapshot().copy(
+                elements = useCase.setSelectedStrokeEnabled(
+                    state.elements, state.selectedIds, intent.enabled,
+                ),
+            )
+        }
         is Intent.SetSelectedStrokeWidth -> {
             if (state.selectedIds.isEmpty()) state
             else state.snapshot().copy(

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -263,6 +263,20 @@ class DrawBoxController(
     /** Recolor every selected element's stroke. */
     fun setSelectionColor(color: Color) = onIntent(Intent.SetSelectedStrokeColor(color))
 
+    /**
+     * Set the fill color of every selected shape. Pass `null` to clear fill so
+     * the shape renders stroke-only.
+     */
+    fun setSelectionFillColor(color: Color?) =
+        onIntent(Intent.SetSelectedFillColor(color))
+
+    /**
+     * Toggle the stroke pass on every selected shape. `false` makes the shape
+     * fill-only; `true` restores its outline.
+     */
+    fun setSelectionStrokeEnabled(enabled: Boolean) =
+        onIntent(Intent.SetSelectedStrokeEnabled(enabled))
+
     /** Re-stroke every selected element. */
     fun setSelectionStrokeWidth(width: Float) = onIntent(Intent.SetSelectedStrokeWidth(width))
 

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -131,6 +131,14 @@ fun HomeScreen(
         is Element.Path -> first.strokeWidth
         else -> state.strokeWidth
     }
+    // Fill + stroke-toggle are shape-only. Both are shown whenever the
+    // selection contains at least one Shape; the swatches reflect that shape's
+    // current fill / stroke state.
+    val selectedShapes = selectedDrawables.filterIsInstance<Element.Shape>()
+    val showFill = selectedShapes.isNotEmpty()
+    val showStrokeToggle = selectedShapes.isNotEmpty()
+    val currentFillColor = selectedShapes.firstOrNull()?.fillColor
+    val currentStrokeEnabled = selectedShapes.firstOrNull()?.strokeEnabled ?: true
 
     // Drawer + bg-pattern state.
     var drawerOpen by remember { mutableStateOf(false) }
@@ -186,7 +194,11 @@ fun HomeScreen(
                     isShapeMode = isShapeMode,
                     hasSelection = hasSelection,
                     showCornerRadius = showCornerRadius,
+                    showFill = showFill,
+                    showStrokeToggle = showStrokeToggle,
                     currentColor = currentShapeColor,
+                    currentFillColor = currentFillColor,
+                    currentStrokeEnabled = currentStrokeEnabled,
                     currentStrokeStyle = currentStrokeStyle,
                     currentStrokeWidth = currentStrokeWidth,
                     currentCornerRadius = currentRadius,
@@ -195,6 +207,8 @@ fun HomeScreen(
                         if (hasSelection) viewModel.setSelectionColor(color)
                         else viewModel.setColor(color)
                     },
+                    onFillColorChange = { color -> viewModel.setSelectionFillColor(color) },
+                    onStrokeEnabledChange = { enabled -> viewModel.setSelectionStrokeEnabled(enabled) },
                     onStrokeStyleChange = { style ->
                         if (hasSelection) viewModel.setSelectionStrokeStyle(style)
                         else viewModel.setStrokeStyle(style)

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ContextBar.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ContextBar.kt
@@ -66,12 +66,18 @@ fun ContextBar(
     isShapeMode: Boolean,
     hasSelection: Boolean,
     showCornerRadius: Boolean,
+    showFill: Boolean,
+    showStrokeToggle: Boolean,
     currentColor: Color,
+    currentFillColor: Color?,
+    currentStrokeEnabled: Boolean,
     currentStrokeStyle: StrokeStyle,
     currentStrokeWidth: Float,
     currentCornerRadius: Float,
     expanded: Boolean,
     onColorChange: (Color) -> Unit,
+    onFillColorChange: (Color?) -> Unit,
+    onStrokeEnabledChange: (Boolean) -> Unit,
     onStrokeStyleChange: (StrokeStyle) -> Unit,
     onStrokeWidthChange: (Float) -> Unit,
     onCornerRadiusChange: (Float) -> Unit,
@@ -92,19 +98,102 @@ fun ContextBar(
             onColorSelected = onColorChange,
         )
     }
+    var showFillDialog by remember { mutableStateOf(false) }
+    if (showFillDialog) {
+        ColorPickerDialog(
+            // RangVikalp has no "null" state — seed with the current fill or
+            // the stroke color so the picker opens on something sensible.
+            initialColor = currentFillColor ?: currentColor,
+            onDismiss = { showFillDialog = false },
+            onColorSelected = { onFillColorChange(it) },
+        )
+    }
 
     val active = MaterialTheme.colorScheme.primary
     val inactive = MaterialTheme.colorScheme.onSurfaceVariant
     val errorTint = MaterialTheme.colorScheme.error
 
     val items = buildList {
-        add(
-            FloatingMenuItem(
-                id = "color",
-                icon = { _ -> ColorSwatchIcon(color = currentColor) },
-                onClick = { showColorDialog = true },
-            ),
-        )
+        // When a shape is selected, the stroke slot becomes a parent that
+        // exposes both "no stroke" and a color picker so the user can express
+        // all three states (stroke-only / fill-only / both) from one place.
+        // In shape-mode without selection it stays a one-shot picker — there's
+        // no per-shape stroke yet to toggle.
+        if (showStrokeToggle) {
+            add(
+                FloatingMenuItem(
+                    id = "color",
+                    icon = { _ ->
+                        StrokeSwatchIcon(
+                            color = currentColor,
+                            enabled = currentStrokeEnabled,
+                        )
+                    },
+                    children = listOf(
+                        FloatingMenuItem(
+                            id = "stroke-none",
+                            isActive = !currentStrokeEnabled,
+                            icon = { isActive ->
+                                StrokeNoneIcon(color = isActive.getActiveColor())
+                            },
+                            onClick = { onStrokeEnabledChange(false) },
+                        ),
+                        FloatingMenuItem(
+                            id = "stroke-pick",
+                            isActive = currentStrokeEnabled,
+                            icon = { _ ->
+                                StrokeSwatchIcon(
+                                    color = currentColor,
+                                    enabled = true,
+                                )
+                            },
+                            onClick = {
+                                // Picking a color implies "stroke on" — saves a
+                                // round-trip if the user came from the no-stroke
+                                // state.
+                                if (!currentStrokeEnabled) onStrokeEnabledChange(true)
+                                showColorDialog = true
+                            },
+                        ),
+                    ),
+                ),
+            )
+        } else {
+            add(
+                FloatingMenuItem(
+                    id = "color",
+                    icon = { _ -> ColorSwatchIcon(color = currentColor) },
+                    onClick = { showColorDialog = true },
+                ),
+            )
+        }
+
+        if (showFill) {
+            add(
+                FloatingMenuItem(
+                    id = "fill",
+                    icon = { _ -> FillSwatchIcon(color = currentFillColor) },
+                    children = listOf(
+                        FloatingMenuItem(
+                            id = "fill-none",
+                            isActive = currentFillColor == null,
+                            icon = { isActive ->
+                                FillNoneIcon(color = isActive.getActiveColor())
+                            },
+                            onClick = { onFillColorChange(null) },
+                        ),
+                        FloatingMenuItem(
+                            id = "fill-pick",
+                            isActive = currentFillColor != null,
+                            icon = { _ ->
+                                FillSwatchIcon(color = currentFillColor)
+                            },
+                            onClick = { showFillDialog = true },
+                        ),
+                    ),
+                ),
+            )
+        }
 
         if (showConfig) {
             add(
@@ -256,6 +345,102 @@ private fun ColorSwatchIcon(color: Color) {
             .background(color)
             .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape),
     )
+}
+
+/**
+ * Same shape as [ColorSwatchIcon] but adds a slash overlay when the stroke is
+ * disabled — visually pairs with [FillSwatchIcon]'s null-state.
+ */
+@Composable
+private fun StrokeSwatchIcon(color: Color, enabled: Boolean) {
+    val outline = MaterialTheme.colorScheme.outline
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .clip(CircleShape)
+            .background(if (enabled) color else Color.Transparent)
+            .border(1.dp, outline, CircleShape),
+    ) {
+        if (!enabled) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawLine(
+                    color = outline,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, 0f),
+                    strokeWidth = 2f,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StrokeNoneIcon(color: Color) {
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .clip(CircleShape)
+            .border(1.dp, color, CircleShape),
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawLine(
+                color = color,
+                start = Offset(0f, size.height),
+                end = Offset(size.width, 0f),
+                strokeWidth = 2f,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FillSwatchIcon(color: Color?) {
+    val outline = MaterialTheme.colorScheme.outline
+    val shape = RoundedCornerShape(4.dp)
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .clip(shape)
+            .background(color ?: Color.Transparent)
+            .border(1.dp, outline, shape),
+    ) {
+        if (color == null) {
+            // Diagonal slash to communicate "no fill" — same visual idiom as
+            // the SettingsDrawer's transparent-bg swatch.
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawLine(
+                    color = outline,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, 0f),
+                    strokeWidth = 2f,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FillNoneIcon(color: Color) {
+    val shape = RoundedCornerShape(4.dp)
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .clip(shape)
+            .border(1.dp, color, shape),
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawLine(
+                color = color,
+                start = Offset(0f, size.height),
+                end = Offset(size.width, 0f),
+                strokeWidth = 2f,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary

- Decouples Shape's fill and stroke paints — a shape can now have both, either alone, or neither.
- Adds `Element.Shape.strokeEnabled` so the outline can be removed without zeroing `strokeWidth`.
- New intents / controller methods: `SetSelectedFillColor`, `SetSelectedStrokeEnabled`.
- ContextBar gets stroke + fill swatch dropdowns with explicit "none" states.
- SVG export honors the new toggle.

Closes #77.

## Test plan

- [x] Draw a rectangle, set both a fill and a stroke color — verify filled body with contrasting outline.
- [x] Toggle stroke off via ContextBar — border disappears, fill unchanged.
- [x] Toggle fill off — hollow outline.
- [x] Export JSON, re-import — `strokeEnabled` and `fillColor` round-trip independently.
- [x] Open an old (pre-feature) JSON file — every shape loads with stroke on by default.
- [x] Export SVG with a fill-only shape — Inkscape / Chrome / Figma show no border.
- [x] LINE / ARROW selection: fill / stroke-toggle controls hidden (they're stroke-only).