### PR TITLE
feat: plain-text element with inline editor and font controls (closes #74)

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.text.drawText
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -156,6 +157,14 @@ fun DrawBox(
     onIntent: (Intent) -> Unit,
     modifier: Modifier = Modifier.fillMaxSize(),
     showGrid: Boolean = true,
+    /**
+     * IDs of elements that should be skipped entirely by the renderer and
+     * the selection chrome. Used by the sample app to suppress the
+     * underlying text while an inline editor overlays it; without this the
+     * editing TextField and the rendered text element would double-paint
+     * the same content (and ghost as the user types).
+     */
+    hiddenElementIds: Set<String> = emptySet(),
 ) {
     // Two-layer split:
     //   - finalizedLayer: cached display list of "static" elements (everything not
@@ -176,6 +185,41 @@ fun DrawBox(
     // Same idea for images: decode once per (id, bytes ref), reuse the
     // ImageBitmap across frames. Re-decoded only when bytes reference changes.
     val imageCache = remember { ImageBitmapCache() }
+    // Text layout cache: lay out each text block once per (id, text, style,
+    // wrap width); reuse the result on subsequent frames. TextMeasurer is
+    // composition-scoped and must come from rememberTextMeasurer.
+    val textMeasurer = androidx.compose.ui.text.rememberTextMeasurer()
+    val textCache = remember { TextLayoutCache() }
+
+    // Pre-measure every text element at composition time (cache hit when
+    // unchanged) and dispatch SyncTextMeasuredHeight when the rendered
+    // height drifts from what the model has stored. This is the loop that
+    // keeps bounds() / hit-test / selection chrome accurate without putting
+    // a TextMeasurer in the data layer.
+    //
+    // The effect runs after composition completes, so the first frame after
+    // an InsertText draws with the initial-guess height. The sync intent
+    // fires immediately, the reducer accepts (no snapshot), and the second
+    // frame has the correct geometry. The 0.5px drift gate in both the
+    // dispatch and the reducer ensures fixed-point convergence in one step.
+    LaunchedEffect(state.elements, textMeasurer) {
+        state.elements.forEach { el ->
+            if (el !is Element.Text) return@forEach
+            val layout = textCache.layoutFor(
+                id = el.id,
+                text = el.text,
+                fontFamilyKey = el.fontFamilyKey,
+                fontSize = el.fontSize,
+                alignment = el.alignment,
+                wrapWidth = el.wrapWidth.coerceAtLeast(1f),
+                measurer = textMeasurer,
+            )
+            val measured = layout.size.height.toFloat()
+            if (kotlin.math.abs(measured - el.measuredHeight) > 0.5f) {
+                onIntent(Intent.SyncTextMeasuredHeight(el.id, measured))
+            }
+        }
+    }
 
     // Drag-in-progress signal lifted out of the gesture coroutine so the render
     // path can tell when an element is being actively mutated (drawn, moved,
@@ -465,6 +509,21 @@ fun DrawBox(
                                 latestOnIntent(Intent.EraseAt(world, s.eraserSize / s.viewport.scale))
                                 latestOnIntent(Intent.EndErase)
                             }
+                            Mode.TEXT -> {
+                                // Drop an empty Text element at the tap, using
+                                // the State defaults the user pre-configured via
+                                // the ContextBar before tapping. Matches the
+                                // shape-mode pattern where stroke/fill/etc. are
+                                // pre-chosen before drawing.
+                                latestOnIntent(Intent.InsertText(
+                                    text = "",
+                                    position = world,
+                                    fontSize = s.currentItemFontSize,
+                                    fontFamilyKey = s.currentItemFontFamilyKey,
+                                    alignment = s.currentItemTextAlignment,
+                                    color = s.strokeColor,
+                                ))
+                            }
                             else -> modeShapeType(s.effectiveMode)?.let { st ->
                                 latestOnIntent(Intent.InsertNewShape(st, world))
                                 latestOnIntent(Intent.UpdateLatestShape(world))
@@ -678,6 +737,11 @@ fun DrawBox(
                     // empty and let staticRefsMatch handle the cache rebuild
                     // when the element list shrinks.
                     Mode.ERASER -> emptySet()
+                    // Text insertion is single-step (tap → InsertText with an
+                    // empty content), so there's no "drag-being-mutated"
+                    // element to mark active. The sample app's modal editor
+                    // dispatches the eventual UpdateText separately.
+                    Mode.TEXT -> emptySet()
                     Mode.PEN, Mode.RECTANGLE, Mode.CIRCLE, Mode.TRIANGLE, Mode.ARROW, Mode.LINE -> {
                         val lastId = orderedElements.lastOrNull()?.id
                         if (lastId == null) emptySet() else setOf(lastId)
@@ -686,10 +750,19 @@ fun DrawBox(
             }
 
             // Freshness check on the cached layer. Walks orderedElements once,
-            // comparing non-active entries against lastRecordedStaticRefs by
-            // reference (allocation-free).
+            // comparing non-active and non-hidden entries against
+            // lastRecordedStaticRefs by reference (allocation-free). Hidden
+            // ids are skipped so a freshly-hidden element invalidates the
+            // cache instead of replaying from a recording made before it was
+            // hidden (otherwise the inline editor would ghost over the
+            // still-cached text).
             val cacheFresh = lastRecordedVp == vp &&
-                staticRefsMatch(orderedElements, activeIds, lastRecordedStaticRefs)
+                staticRefsMatch(
+                    orderedElements,
+                    activeIds,
+                    hiddenElementIds,
+                    lastRecordedStaticRefs,
+                )
 
             if (!cacheFresh) {
                 // Re-record at screen-space (transform baked in). This means
@@ -702,12 +775,15 @@ fun DrawBox(
                         scale(vp.scale, vp.scale, pivot = Offset.Zero)
                     }) {
                         orderedElements.forEach { el ->
-                            if (el.id !in activeIds) renderElement(el, pathCache, imageCache)
+                            if (el.id !in activeIds && el.id !in hiddenElementIds) {
+                                renderElement(el, pathCache, imageCache, textCache, textMeasurer)
+                            }
                         }
                     }
                 }
                 lastRecordedVp = vp
-                lastRecordedStaticRefs = orderedElements.filter { it.id !in activeIds }
+                lastRecordedStaticRefs = orderedElements
+                    .filter { it.id !in activeIds && it.id !in hiddenElementIds }
             }
 
             // Play the cached static layer. No transform — it was baked in at
@@ -722,7 +798,7 @@ fun DrawBox(
             }) {
                 if (activeIds.isNotEmpty()) {
                     orderedElements.forEach { el ->
-                        if (el.id in activeIds) renderElement(el, pathCache, imageCache)
+                        if (el.id in activeIds && el.id !in hiddenElementIds) renderElement(el, pathCache, imageCache, textCache, textMeasurer)
                     }
                 }
                 drawSelectionChrome(
@@ -730,6 +806,7 @@ fun DrawBox(
                     handleSizePx = handleSizePx,
                     rotationOffsetPx = rotationOffsetPx,
                     inverseScale = 1f / vp.scale,
+                    hiddenElementIds = hiddenElementIds,
                 )
                 // Eraser cursor overlay: outline circle at the world-space
                 // pointer with the configured eraser radius. Drawn inside the
@@ -763,7 +840,7 @@ fun DrawBox(
                         translate(vp.offset.x, vp.offset.y)
                         scale(vp.scale, vp.scale, pivot = Offset.Zero)
                     }) {
-                        orderedElements.forEach { renderElement(it, pathCache, imageCache) }
+                        orderedElements.forEach { renderElement(it, pathCache, imageCache, textCache, textMeasurer) }
                     }
                 }
                 capturePending = false
@@ -776,13 +853,14 @@ fun DrawBox(
                 }
             }
 
-            // Reclaim PathCache + ImageBitmapCache entries for deleted elements.
-            // Cheap (HashMap key-retain over the live id set); only worth doing
-            // when the live set actually shrank.
-            if (pathCache.size() + imageCache.size() > state.elements.size) {
+            // Reclaim PathCache + ImageBitmapCache + TextLayoutCache entries
+            // for deleted elements. Cheap (HashMap key-retain over the live id
+            // set); only worth doing when the live set actually shrank.
+            if (pathCache.size() + imageCache.size() + textCache.size() > state.elements.size) {
                 val liveIds = state.elements.mapTo(HashSet(state.elements.size)) { it.id }
                 pathCache.retainOnly(liveIds)
                 imageCache.retainOnly(liveIds)
+                textCache.retainOnly(liveIds)
             }
         }
     }
@@ -863,7 +941,7 @@ private fun modeShapeType(mode: Mode): ShapeType? = when (mode) {
     Mode.TRIANGLE -> ShapeType.TRIANGLE
     Mode.ARROW -> ShapeType.ARROW
     Mode.LINE -> ShapeType.LINE
-    Mode.PEN, Mode.SELECT, Mode.PAN, Mode.ERASER -> null
+    Mode.PEN, Mode.SELECT, Mode.PAN, Mode.ERASER, Mode.TEXT -> null
 }
 
 // ==================== Selection gesture support ====================
@@ -1006,11 +1084,12 @@ private fun DrawScope.drawSelectionChrome(
     handleSizePx: Float,
     rotationOffsetPx: Float,
     inverseScale: Float,
+    hiddenElementIds: Set<String> = emptySet(),
 ) {
     val rotationOffsetWorld = rotationOffsetPx * inverseScale
     state.elements
         .asSequence()
-        .filter { it.id in state.selectedIds }
+        .filter { it.id in state.selectedIds && it.id !in hiddenElementIds }
         .forEach { el ->
             // LINE / ARROW get a minimal 3-dot chrome: start, end, and bend midpoint.
             if (el is Element.Shape && el.shapeType.isLineLike() && el.points.size >= 2) {
@@ -1193,12 +1272,14 @@ private fun DrawScope.renderElement(
     element: Element,
     pathCache: PathCache? = null,
     imageCache: ImageBitmapCache? = null,
+    textCache: TextLayoutCache? = null,
+    textMeasurer: androidx.compose.ui.text.TextMeasurer? = null,
 ) {
     if (element.rotation == 0f) {
-        renderElementContent(element, pathCache, imageCache)
+        renderElementContent(element, pathCache, imageCache, textCache, textMeasurer)
     } else {
         withTransform({ rotate(element.rotation, pivot = element.bounds().center) }) {
-            renderElementContent(element, pathCache, imageCache)
+            renderElementContent(element, pathCache, imageCache, textCache, textMeasurer)
         }
     }
 }
@@ -1207,6 +1288,8 @@ private fun DrawScope.renderElementContent(
     element: Element,
     pathCache: PathCache?,
     imageCache: ImageBitmapCache?,
+    textCache: TextLayoutCache?,
+    textMeasurer: androidx.compose.ui.text.TextMeasurer?,
 ) {
     when (element) {
         is Element.Path -> {
@@ -1256,7 +1339,53 @@ private fun DrawScope.renderElementContent(
         is Element.Image -> {
             drawImageElement(element, imageCache)
         }
+        is Element.Text -> {
+            drawTextElement(element, textCache, textMeasurer)
+        }
     }
+}
+
+/**
+ * Render an [Element.Text] inside its wrap box. Layout is delegated to
+ * [TextLayoutCache] so re-rendering an unchanged block is allocation-free.
+ *
+ * When the layout cache or [textMeasurer] isn't available (e.g. the
+ * read-only [DrawingPreview] preview path), the element falls back to a
+ * grey placeholder rectangle — preview surfaces don't need to lay out
+ * text and would otherwise pay a TextMeasurer cost per frame.
+ */
+private fun DrawScope.drawTextElement(
+    element: Element.Text,
+    textCache: TextLayoutCache?,
+    textMeasurer: androidx.compose.ui.text.TextMeasurer?,
+) {
+    val wrapWidth = element.wrapWidth.coerceAtLeast(1f)
+    if (textCache == null || textMeasurer == null) {
+        // Preview path: outline the wrap box so the reader can see the
+        // placeholder. No layout cost.
+        drawRect(
+            color = Color(0x33888888),
+            topLeft = element.topLeft,
+            size = Size(wrapWidth, element.measuredHeight.coerceAtLeast(1f)),
+            style = Stroke(width = 1f),
+        )
+        return
+    }
+    val layout = textCache.layoutFor(
+        id = element.id,
+        text = element.text,
+        fontFamilyKey = element.fontFamilyKey,
+        fontSize = element.fontSize,
+        alignment = element.alignment,
+        wrapWidth = wrapWidth,
+        measurer = textMeasurer,
+    )
+    drawText(
+        textLayoutResult = layout,
+        color = element.color,
+        topLeft = element.topLeft,
+        alpha = element.opacity,
+    )
 }
 
 /**

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/Helper.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/Helper.kt
@@ -5,7 +5,16 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
 import io.ak1.drawbox.domain.model.Element
+import io.ak1.drawbox.domain.model.TextAlignment
+import io.ak1.drawbox.text.FontRegistry
 
 
 fun createPath(points: List<Offset>) = Path().apply {
@@ -32,24 +41,31 @@ private fun calculateMidpoint(start: Offset, end: Offset) = Offset((start.x + en
 
 /**
  * Allocation-free check: do the entries of [current] (in order, excluding those
- * whose id is in [activeIds]) exactly match [reference] by reference identity?
+ * whose id is in [activeIds] or [hiddenIds]) exactly match [reference] by
+ * reference identity?
  *
  * Used as the freshness gate for the cached `finalizedLayer` recording in
  * `DrawBox`. The reducer always produces a fresh [Element] instance via
  * `copy(...)` on any mutation, so reference equality is both correct (catches
  * every meaningful change) and cheap (no field comparison).
  *
+ * [hiddenIds] is what flips a cache that was recorded *before* the host
+ * decided to hide an element. Without including it in the skip set, a Text
+ * element about to be edited inline would replay from the cache and ghost
+ * underneath the editor.
+ *
  * Iterates `current` exactly once, no intermediate list, no boxed iterators.
  */
 internal fun staticRefsMatch(
     current: List<Element>,
     activeIds: Set<String>,
+    hiddenIds: Set<String>,
     reference: List<Element>,
 ): Boolean {
     var refIdx = 0
     for (idx in 0 until current.size) {
         val e = current[idx]
-        if (e.id in activeIds) continue
+        if (e.id in activeIds || e.id in hiddenIds) continue
         if (refIdx >= reference.size) return false
         if (reference[refIdx] !== e) return false
         refIdx++
@@ -142,4 +158,69 @@ internal class ImageBitmapCache {
     }
 
     fun size(): Int = byId.size
+}
+
+/**
+ * Per-canvas cache of [TextLayoutResult] entries for [Element.Text]
+ * elements. Laying out a multi-line block runs the platform text shaper —
+ * cheap individually but cumulative across hundreds of elements per frame.
+ *
+ * The cache key is the tuple of fields that participate in layout: the
+ * text content, font family key, font size, alignment, and wrap width.
+ * Anything else (color, opacity, rotation, position) is applied at draw
+ * time and doesn't invalidate the layout.
+ *
+ * Entries survive recompositions via `remember`; stale entries are
+ * reclaimed by [retainOnly] when the live element set shrinks.
+ */
+internal class TextLayoutCache {
+    private data class Key(
+        val text: String,
+        val fontFamilyKey: String,
+        val fontSize: Float,
+        val alignment: TextAlignment,
+        val wrapWidth: Float,
+    )
+    private data class Entry(val key: Key, val layout: TextLayoutResult)
+    private val byId = HashMap<String, Entry>()
+
+    fun layoutFor(
+        id: String,
+        text: String,
+        fontFamilyKey: String,
+        fontSize: Float,
+        alignment: TextAlignment,
+        wrapWidth: Float,
+        measurer: TextMeasurer,
+    ): TextLayoutResult {
+        val key = Key(text, fontFamilyKey, fontSize, alignment, wrapWidth)
+        val existing = byId[id]
+        if (existing != null && existing.key == key) return existing.layout
+        val style = TextStyle(
+            fontSize = fontSize.sp,
+            fontFamily = FontRegistry.resolve(fontFamilyKey),
+            textAlign = alignment.toComposeAlign(),
+        )
+        val layout = measurer.measure(
+            text = text,
+            style = style,
+            constraints = Constraints(maxWidth = wrapWidth.toInt().coerceAtLeast(1)),
+            softWrap = true,
+        )
+        byId[id] = Entry(key, layout)
+        return layout
+    }
+
+    fun retainOnly(liveIds: Set<String>) {
+        if (byId.isEmpty()) return
+        byId.keys.retainAll(liveIds)
+    }
+
+    fun size(): Int = byId.size
+}
+
+private fun TextAlignment.toComposeAlign(): TextAlign = when (this) {
+    TextAlignment.LEFT -> TextAlign.Left
+    TextAlignment.CENTER -> TextAlign.Center
+    TextAlignment.RIGHT -> TextAlign.Right
 }

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Element.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Element.kt
@@ -199,6 +199,57 @@ sealed class Element {
         }
     }
 
+    /**
+     * Block-level plain-text element. Single style applies to the whole block;
+     * rich-text features (inline bold / italic spans, links, cursor-within-text
+     * editing) are intentionally NOT in scope here and are tracked separately.
+     *
+     * Two-piece geometry — the user owns the *wrap width*, the renderer owns
+     * the *measured height*. After every layout, if the rendered height drifts
+     * from [measuredHeight], the renderer dispatches a non-snapshotting
+     * [io.ak1.drawbox.domain.model.Intent.SyncTextMeasuredHeight] to bring the
+     * model back in sync — so [bounds] is always accurate without the data
+     * layer needing a [androidx.compose.ui.text.TextMeasurer].
+     *
+     * Resize semantics follow from this split: dragging a horizontal handle
+     * changes [wrapWidth] (causing a re-wrap and a height update on the next
+     * frame); dragging a vertical handle is a no-op since height is auto.
+     *
+     * @property text Raw string content. Newlines (`\n`) are honored as hard
+     *   breaks; auto-wrap fills each visual line up to [wrapWidth].
+     * @property fontFamilyKey Logical name resolved via the host-side
+     *   [io.ak1.drawbox.presentation.viewmodel.DrawBoxController.registerFont]
+     *   registry. Unknown keys fall back to `sans`.
+     * @property fontSize Em size in world pixels.
+     * @property color Text color.
+     * @property alignment Horizontal alignment inside the wrap box.
+     * @property topLeft World-space top-left corner of the wrap box.
+     * @property wrapWidth World-space wrap width — the only knob the user
+     *   manipulates via resize handles.
+     * @property measuredHeight Renderer-owned cached height. Initialized to a
+     *   single-line guess at insertion time and refreshed by the sync intent
+     *   after the first layout pass. Never written by user gestures.
+     * @property opacity Render-time alpha (0.0..1.0), independent of [color]'s
+     *   own alpha channel.
+     */
+    data class Text(
+        override val id: String = Uuid.random().toString(),
+        override val type: String = "Text",
+        val text: String,
+        val fontFamilyKey: String = DEFAULT_FONT_FAMILY_KEY,
+        val fontSize: Float,
+        val color: Color,
+        val alignment: TextAlignment = TextAlignment.LEFT,
+        val topLeft: Offset,
+        val wrapWidth: Float,
+        val measuredHeight: Float,
+        val opacity: Float = 1f,
+        override val zIndex: Int = 0,
+        override val rotation: Float = 0f,
+        override val createdAt: Long = 0L,
+        override val modifiedAt: Long = 0L,
+    ) : Element()
+
     data class Shape(
         override val id: String = Uuid.random().toString(),
         override val type: String = "Shape",
@@ -264,7 +315,27 @@ fun Element.touched(now: Long = kotlin.time.Clock.System.now().toEpochMillisecon
         is Element.Path -> copy(modifiedAt = now)
         is Element.Shape -> copy(modifiedAt = now)
         is Element.Image -> copy(modifiedAt = now)
+        is Element.Text -> copy(modifiedAt = now)
     }
+
+/**
+ * Horizontal alignment inside an [Element.Text]'s wrap box.
+ */
+enum class TextAlignment { LEFT, CENTER, RIGHT }
+
+/**
+ * Default font family key used when no [Element.Text.fontFamilyKey] is
+ * specified and as the fallback when a referenced key isn't registered.
+ */
+const val DEFAULT_FONT_FAMILY_KEY: String = "sans"
+
+/** Keys for the SDK's built-in font families. Hosts can register additional
+ *  families via the controller; these three are always available. */
+object BuiltinFontFamilyKeys {
+    const val SANS: String = "sans"
+    const val SERIF: String = "serif"
+    const val MONO: String = "mono"
+}
 
 /**
  * Defines how [Element.Shape] is rendered on the canvas.

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Geometry.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Geometry.kt
@@ -25,6 +25,12 @@ import kotlin.math.sqrt
 fun Element.bounds(): Rect = when (this) {
     is Element.Path -> pointsBounds(positions)
     is Element.Image -> pointsBounds(points)
+    is Element.Text -> Rect(
+        left = topLeft.x,
+        top = topLeft.y,
+        right = topLeft.x + wrapWidth,
+        bottom = topLeft.y + measuredHeight,
+    )
     is Element.Shape -> when (shapeType) {
         // Circle points are diameter endpoints, so the circle extends past them.
         // The bbox is the square inscribing the circle.
@@ -291,6 +297,7 @@ fun Element.hitTest(point: Offset, tolerance: Float = 8f): Boolean {
         is Element.Path -> hitTestPath(this, local, tolerance)
         is Element.Shape -> hitTestShape(this, local, b, tolerance)
         is Element.Image -> b.inflate(tolerance).contains(local)
+        is Element.Text -> b.inflate(tolerance).contains(local)
     }
 }
 
@@ -405,6 +412,7 @@ fun Element.translate(delta: Offset): Element = when (this) {
     ).touched()
     is Element.Shape -> copy(points = points.map { it + delta }).touched()
     is Element.Image -> copy(points = points.map { it + delta }).touched()
+    is Element.Text -> copy(topLeft = topLeft + delta).touched()
 }
 
 /**
@@ -426,6 +434,15 @@ fun Element.withBounds(newBounds: Rect): Element {
         }
         is Element.Image -> copy(
             points = listOf(safeBounds.topLeft, safeBounds.bottomRight),
+        ).touched()
+        // Resize for text only honors the X extents (topLeft.x + wrapWidth)
+        // and the topLeft.y. Bottom-edge drags are silently ignored — the
+        // renderer owns measuredHeight and will refresh it on the next
+        // layout pass via Intent.SyncTextMeasuredHeight. This makes vertical
+        // handles a visual no-op, matching the behavior in tldraw / Figma.
+        is Element.Text -> copy(
+            topLeft = safeBounds.topLeft,
+            wrapWidth = safeBounds.width,
         ).touched()
         is Element.Shape -> when (shapeType) {
             ShapeType.CIRCLE -> resizeCircle(this, safeBounds).touched()
@@ -486,6 +503,7 @@ fun Element.withRotation(degrees: Float): Element = when (this) {
     is Element.Path -> copy(rotation = degrees).touched()
     is Element.Shape -> copy(rotation = degrees).touched()
     is Element.Image -> copy(rotation = degrees).touched()
+    is Element.Text -> copy(rotation = degrees).touched()
 }
 
 /**

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
@@ -93,6 +93,75 @@ sealed class Intent {
         }
     }
 
+    // ==================== Text Operations ====================
+
+    /**
+     * Insert an [Element.Text] at [position] with the given style. The wrap
+     * box is sized from a sensible default width; embedders that want a
+     * different layout can dispatch [SetElementBounds] immediately after.
+     * Snapshots history once.
+     */
+    data class InsertText(
+        val text: String,
+        val position: Offset,
+        val fontSize: Float,
+        val fontFamilyKey: String,
+        val alignment: TextAlignment,
+        val color: Color,
+    ) : Intent()
+
+    /**
+     * Replace the [text] content of an existing [Element.Text]. Snapshots
+     * history so a typing session can be undone as a single revision when
+     * the embedder commits with a single dispatch (typical for modal
+     * editors); embedders implementing inline editing should batch their
+     * own undo boundaries.
+     */
+    data class UpdateText(val id: String, val text: String) : Intent()
+
+    /** Replace font size on every selected text element. Snapshots history. */
+    data class SetSelectedFontSize(val size: Float) : Intent()
+
+    /** Replace text alignment on every selected text element. Snapshots history. */
+    data class SetSelectedTextAlignment(val alignment: TextAlignment) : Intent()
+
+    /** Replace font family key on every selected text element. Snapshots history. */
+    data class SetSelectedFontFamily(val fontFamilyKey: String) : Intent()
+
+    /**
+     * Default font size for future text inserts. Mirrors [SetStrokeWidth] for
+     * shapes: mutates the State default without touching any existing element.
+     * Not history-tracked — the default is session-level UI state.
+     */
+    data class SetFontSize(val size: Float) : Intent()
+
+    /** Default font family key for future text inserts. Not history-tracked. */
+    data class SetFontFamily(val fontFamilyKey: String) : Intent()
+
+    /** Default text alignment for future text inserts. Not history-tracked. */
+    data class SetTextAlignment(val alignment: TextAlignment) : Intent()
+
+    /**
+     * Renderer-driven height reconciliation for a single text element.
+     *
+     * The canvas measures the text's actual rendered height each frame; when
+     * that differs from [Element.Text.measuredHeight], it fires this intent
+     * so the model converges to what the user actually sees. Behavior notes:
+     *
+     * - Does **not** snapshot history — this is fixed-point convergence
+     *   driven by the renderer, not a user gesture, so it must not consume
+     *   undo slots or split a typing session across multiple reverts.
+     * - Does **not** bump `modifiedAt` — measuredHeight is renderer-cached
+     *   state, not a user edit; bumping LWW would corrupt collab merge.
+     * - Is idempotent — re-dispatching with the same value is a no-op (the
+     *   reducer short-circuits when the existing value is within 0.5px).
+     *
+     * Embedders building custom renderers should mirror this contract. The
+     * intent is intentionally typed so it cannot be confused with user-edit
+     * intents that DO snapshot.
+     */
+    data class SyncTextMeasuredHeight(val id: String, val height: Float) : Intent()
+
     // ==================== Shape Operations ====================
 
     /**

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Serialization.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Serialization.kt
@@ -157,8 +157,24 @@ data class ElementDto(
     val intrinsicWidth: Float? = null,
     /** Source image's intrinsic pixel height. Only set for Image elements. */
     val intrinsicHeight: Float? = null,
-    /** Render-time alpha for Image elements (0.0..1.0). */
+    /** Render-time alpha for Image / Text elements (0.0..1.0). */
     val opacity: Float? = null,
+    /** Raw text content. Only set for Text elements. */
+    val text: String? = null,
+    /** Logical font family key resolved by the host's font registry. */
+    val fontFamilyKey: String? = null,
+    /** Em size in world pixels. */
+    val fontSize: Float? = null,
+    /** Horizontal alignment inside the wrap box: `LEFT`, `CENTER`, or `RIGHT`. */
+    val alignment: String? = null,
+    /**
+     * World-space top-left corner of a text element's wrap box, encoded as
+     * `"x,y"`. Only set for Text elements; Shape / Path / Image use the
+     * existing `points` field.
+     */
+    val textTopLeft: String? = null,
+    /** World-space wrap width for a text element. */
+    val wrapWidth: Float? = null,
 )
 
 fun Element.toDto(): ElementDto = when (this) {
@@ -192,6 +208,31 @@ fun Element.toDto(): ElementDto = when (this) {
         intrinsicWidth = intrinsicSize.width,
         intrinsicHeight = intrinsicSize.height,
         opacity = opacity.takeIf { it != 1f },
+    )
+    is Element.Text -> ElementDto(
+        id = id,
+        type = "Text",
+        zIndex = zIndex,
+        // Text geometry moved off the `points` list onto dedicated wire
+        // fields (textTopLeft + wrapWidth). measuredHeight is intentionally
+        // not serialized — it's renderer-cached and refreshed on load by
+        // the first SyncTextMeasuredHeight pass.
+        points = emptyList(),
+        // Text has no stroke; reuse strokeColor as the wire slot for the
+        // text color so legacy readers still parse a meaningful value.
+        // The dedicated `text` / `fontSize` fields below carry the rest.
+        strokeColor = color.toHexString(),
+        strokeWidth = 0f,
+        rotation = rotation.takeIf { it != 0f },
+        createdAt = createdAt.takeIf { it != 0L },
+        modifiedAt = modifiedAt.takeIf { it != 0L },
+        text = text,
+        fontFamilyKey = fontFamilyKey,
+        fontSize = fontSize,
+        alignment = alignment.name,
+        opacity = opacity.takeIf { it != 1f },
+        textTopLeft = topLeft.toJsonString(),
+        wrapWidth = wrapWidth,
     )
     is Element.Shape -> ElementDto(
         id = id,
@@ -245,6 +286,42 @@ fun ElementDto.toElement(): Element = when (type) {
         createdAt = createdAt ?: 0L,
         modifiedAt = modifiedAt ?: createdAt ?: 0L,
     )
+    "Text" -> {
+        val resolvedFontSize = fontSize ?: 24f
+        // Prefer the dedicated `textTopLeft` / `wrapWidth` fields; fall back
+        // to the first/last of `points` for any (in-development) JSON that
+        // predates the two-piece text geometry.
+        val resolvedTopLeft = textTopLeft?.toOffset()
+            ?: points.firstOrNull()?.toOffset()
+            ?: Offset.Zero
+        val resolvedWrapWidth = wrapWidth ?: run {
+            val pts = points.map { it.toOffset() }
+            if (pts.size >= 2) pts.last().x - pts.first().x else 240f
+        }
+        Element.Text(
+            id = id,
+            text = text ?: "",
+            fontFamilyKey = fontFamilyKey ?: io.ak1.drawbox.domain.model.DEFAULT_FONT_FAMILY_KEY,
+            fontSize = resolvedFontSize,
+            color = strokeColor.toColor(),
+            alignment = when (alignment) {
+                "CENTER" -> io.ak1.drawbox.domain.model.TextAlignment.CENTER
+                "RIGHT" -> io.ak1.drawbox.domain.model.TextAlignment.RIGHT
+                else -> io.ak1.drawbox.domain.model.TextAlignment.LEFT
+            },
+            topLeft = resolvedTopLeft,
+            wrapWidth = resolvedWrapWidth.coerceAtLeast(1f),
+            // Single-line guess — the renderer's first layout pass dispatches
+            // SyncTextMeasuredHeight to bring this to the actual rendered
+            // height on the next frame.
+            measuredHeight = (resolvedFontSize * 1.2f).coerceAtLeast(resolvedFontSize),
+            opacity = opacity ?: 1f,
+            zIndex = zIndex,
+            rotation = rotation ?: 0f,
+            createdAt = createdAt ?: 0L,
+            modifiedAt = modifiedAt ?: createdAt ?: 0L,
+        )
+    }
     "Shape" -> Element.Shape(
         id = id,
         shapeType = shapeType?.toShapeType() ?: ShapeType.RECTANGLE,
@@ -318,6 +395,12 @@ data class SerializableElement(
     val intrinsicWidth: Float? = null,
     val intrinsicHeight: Float? = null,
     val opacity: Float? = null,
+    val text: String? = null,
+    val fontFamilyKey: String? = null,
+    val fontSize: Float? = null,
+    val alignment: String? = null,
+    val textTopLeft: String? = null,
+    val wrapWidth: Float? = null,
 )
 
 @kotlinx.serialization.Serializable
@@ -358,6 +441,12 @@ object DrawingSerializer {
                     intrinsicWidth = element.intrinsicWidth,
                     intrinsicHeight = element.intrinsicHeight,
                     opacity = element.opacity,
+                    text = element.text,
+                    fontFamilyKey = element.fontFamilyKey,
+                    fontSize = element.fontSize,
+                    alignment = element.alignment,
+                    textTopLeft = element.textTopLeft,
+                    wrapWidth = element.wrapWidth,
                 )
             },
         )
@@ -393,6 +482,12 @@ object DrawingSerializer {
                     intrinsicWidth = element.intrinsicWidth,
                     intrinsicHeight = element.intrinsicHeight,
                     opacity = element.opacity,
+                    text = element.text,
+                    fontFamilyKey = element.fontFamilyKey,
+                    fontSize = element.fontSize,
+                    alignment = element.alignment,
+                    textTopLeft = element.textTopLeft,
+                    wrapWidth = element.wrapWidth,
                 )
             },
         )

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
@@ -40,6 +40,13 @@ sealed class Mode {
     /** Pan mode - drag pans the camera; useful for navigating the infinite canvas */
     data object PAN : Mode()
     /**
+     * Plain-text mode — tap on the canvas inserts an empty [Element.Text]
+     * at the tap position. The sample app opens a modal text field to
+     * gather the actual content; embedders can mirror that pattern or
+     * provide an inline editor (out of scope for OSS v1).
+     */
+    data object TEXT : Mode()
+    /**
      * Object eraser — tap or drag to delete any element whose body intersects
      * the eraser radius. Whole-element (not pixel-level): a single hit removes
      * the entire stroke or shape. Undoable as one gesture.
@@ -96,6 +103,25 @@ data class State(
     val strokeWidth: Float = 10f,
     val currentItemCornerRadius: Float = 0f,
     val currentItemStrokeStyle: StrokeStyle = StrokeStyle.SOLID,
+    /**
+     * Default font size in world pixels applied to text elements inserted via
+     * [Mode.TEXT]. Mutated by [Intent.SetFontSize] (the non-selection form);
+     * the selection form [Intent.SetSelectedFontSize] writes to the selected
+     * element instead and leaves this default untouched.
+     */
+    val currentItemFontSize: Float = 24f,
+    /**
+     * Default font family key applied to new text elements. See
+     * [Intent.SetFontFamily]. Always resolves via the host's
+     * [io.ak1.drawbox.text.FontRegistry] at render time, so an unregistered
+     * key here falls back to `sans` without crashing the canvas.
+     */
+    val currentItemFontFamilyKey: String = DEFAULT_FONT_FAMILY_KEY,
+    /**
+     * Default horizontal alignment for new text elements; see
+     * [Intent.SetTextAlignment].
+     */
+    val currentItemTextAlignment: TextAlignment = TextAlignment.LEFT,
     val opacity: Float = 1f,
     val bgColor: Color = Color.Black,
     val bgPattern: BackgroundPattern? = null,

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/SvgExporter.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/SvgExporter.kt
@@ -35,6 +35,7 @@ object SvgExporter {
                 is Element.Path -> svgElements.add(pathToSvg(element))
                 is Element.Shape -> svgElements.add(shapeToSvg(element))
                 is Element.Image -> svgElements.add(imageToSvg(element))
+                is Element.Text -> svgElements.add(textToSvg(element))
             }
         }
 
@@ -72,6 +73,16 @@ object SvgExporter {
                         maxX = kotlin.math.max(maxX, point.x)
                         maxY = kotlin.math.max(maxY, point.y)
                     }
+                }
+                is Element.Text -> {
+                    val left = element.topLeft.x
+                    val top = element.topLeft.y
+                    val right = left + element.wrapWidth
+                    val bottom = top + element.measuredHeight
+                    minX = kotlin.math.min(minX, left)
+                    minY = kotlin.math.min(minY, top)
+                    maxX = kotlin.math.max(maxX, right)
+                    maxY = kotlin.math.max(maxY, bottom)
                 }
             }
         }
@@ -259,6 +270,91 @@ object SvgExporter {
 
         return "$lineSvg\n  $headSvg"
     }
+
+    private fun textToSvg(text: Element.Text): String {
+        if (text.text.isEmpty()) return ""
+        val x = text.topLeft.x
+        val y = text.topLeft.y
+        val w = text.wrapWidth
+        val h = text.measuredHeight
+        val anchor = when (text.alignment) {
+            io.ak1.drawbox.domain.model.TextAlignment.LEFT -> "start"
+            io.ak1.drawbox.domain.model.TextAlignment.CENTER -> "middle"
+            io.ak1.drawbox.domain.model.TextAlignment.RIGHT -> "end"
+        }
+        val anchorX = when (text.alignment) {
+            io.ak1.drawbox.domain.model.TextAlignment.LEFT -> x
+            io.ak1.drawbox.domain.model.TextAlignment.CENTER -> x + w * 0.5f
+            io.ak1.drawbox.domain.model.TextAlignment.RIGHT -> x + w
+        }
+        val color = colorToHex(text.color)
+        val opacityAttr = if (text.opacity != 1f) """ opacity="${text.opacity}"""" else ""
+        val transformAttr = if (text.rotation != 0f) {
+            val cx = x + w * 0.5f
+            val cy = y + h * 0.5f
+            """ transform="rotate(${text.rotation}, $cx, $cy)""""
+        } else ""
+        // SVG doesn't natively support box-driven wrapping. Emit one <tspan>
+        // per visual line, splitting on hard `\n` and greedy word-wrap. This
+        // is intentionally lossy for re-import (the wrap rect isn't
+        // recoverable from the visual layout) — JSON is the lossless format.
+        val lineHeight = text.fontSize * 1.25f
+        val lines = wrapTextForSvg(text.text, w, text.fontSize)
+        val tspans = lines.mapIndexed { i, line ->
+            val dy = if (i == 0) text.fontSize else lineHeight
+            """<tspan x="$anchorX" dy="$dy">${escapeXml(line)}</tspan>"""
+        }.joinToString("")
+        return """<text x="$anchorX" y="$y" font-family="${escapeXmlAttr(text.fontFamilyKey)}" font-size="${text.fontSize}" fill="$color" text-anchor="$anchor"$opacityAttr$transformAttr>$tspans</text>"""
+    }
+
+    /**
+     * Cheap line-wrap approximation for SVG export. Estimates characters per
+     * line using a mean glyph width of ~0.55 × fontSize. Honors hard `\n`
+     * breaks; long words break at the character limit. Lossless round-trip
+     * happens through JSON, not SVG.
+     */
+    private fun wrapTextForSvg(text: String, widthWorld: Float, fontSize: Float): List<String> {
+        if (widthWorld <= 0f || fontSize <= 0f) return text.split('\n')
+        val approxCharWidth = fontSize * 0.55f
+        val charsPerLine = (widthWorld / approxCharWidth).toInt().coerceAtLeast(1)
+        val out = mutableListOf<String>()
+        for (hardLine in text.split('\n')) {
+            if (hardLine.length <= charsPerLine) {
+                out += hardLine
+                continue
+            }
+            var current = StringBuilder()
+            for (word in hardLine.split(' ')) {
+                val prospective = if (current.isEmpty()) word
+                else current.toString() + " " + word
+                if (prospective.length <= charsPerLine) {
+                    current = StringBuilder(prospective)
+                } else {
+                    if (current.isNotEmpty()) {
+                        out += current.toString()
+                        current = StringBuilder()
+                    }
+                    var rest = word
+                    while (rest.length > charsPerLine) {
+                        out += rest.substring(0, charsPerLine)
+                        rest = rest.substring(charsPerLine)
+                    }
+                    current = StringBuilder(rest)
+                }
+            }
+            if (current.isNotEmpty()) out += current.toString()
+        }
+        return out
+    }
+
+    private fun escapeXml(s: String): String = s
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+
+    private fun escapeXmlAttr(s: String): String = escapeXml(s)
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;")
 
     private fun imageToSvg(image: Element.Image): String {
         if (image.points.size < 2) return ""

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
@@ -8,6 +8,7 @@ import io.ak1.drawbox.domain.model.Element
 import io.ak1.drawbox.domain.model.ResizeHandle
 import io.ak1.drawbox.domain.model.ShapeType
 import io.ak1.drawbox.domain.model.StrokeStyle
+import io.ak1.drawbox.domain.model.TextAlignment
 import io.ak1.drawbox.domain.model.bounds
 import io.ak1.drawbox.domain.model.connectorAnchor
 import io.ak1.drawbox.domain.model.hitTest
@@ -28,6 +29,7 @@ class UseCase {
             is Element.Path -> element.copy(zIndex = currentElements.size)
             is Element.Shape -> element.copy(zIndex = currentElements.size)
             is Element.Image -> element.copy(zIndex = currentElements.size)
+            is Element.Text -> element.copy(zIndex = currentElements.size)
         }
         return currentElements + newElement
     }
@@ -126,6 +128,87 @@ class UseCase {
             createdAt = now,
             modifiedAt = now,
         )
+    }
+
+    // Text operations
+    @OptIn(ExperimentalTime::class)
+    fun insertText(
+        text: String,
+        position: Offset,
+        fontSize: Float,
+        fontFamilyKey: String,
+        alignment: TextAlignment,
+        color: Color,
+    ): Element.Text {
+        val now = Clock.System.now().toEpochMilliseconds()
+        // Initial guess: a single-line block at fontSize*1.2 tall. The
+        // renderer dispatches Intent.SyncTextMeasuredHeight after the first
+        // layout pass, so this value is only ever visible for one frame.
+        return Element.Text(
+            text = text,
+            fontFamilyKey = fontFamilyKey,
+            fontSize = fontSize,
+            color = color,
+            alignment = alignment,
+            topLeft = position,
+            wrapWidth = DEFAULT_TEXT_BOX_WIDTH,
+            measuredHeight = (fontSize * 1.2f).coerceAtLeast(fontSize),
+            createdAt = now,
+            modifiedAt = now,
+        )
+    }
+
+    /**
+     * Renderer-driven height sync — the canvas measures a text block, sees
+     * the rendered height differs from [Element.Text.measuredHeight] and
+     * dispatches [io.ak1.drawbox.domain.model.Intent.SyncTextMeasuredHeight]
+     * to bring the model in line. Bypasses history so this fixed-point
+     * convergence doesn't consume undo slots.
+     */
+    fun syncTextMeasuredHeight(
+        elements: List<Element>,
+        id: String,
+        height: Float,
+    ): List<Element> = elements.map { el ->
+        if (el is Element.Text && el.id == id) el.copy(measuredHeight = height)
+        else el
+    }
+
+    /** Replace the [text] field of a single [Element.Text]. Snapshots history. */
+    fun updateText(
+        elements: List<Element>,
+        id: String,
+        text: String,
+    ): List<Element> = elements.map { el ->
+        if (el.id == id && el is Element.Text) el.copy(text = text).touched()
+        else el
+    }
+
+    /** Set font size on every selected [Element.Text]. */
+    fun setSelectedFontSize(
+        elements: List<Element>,
+        ids: Set<String>,
+        size: Float,
+    ): List<Element> = elements.map { el ->
+        if (el.id in ids && el is Element.Text) el.copy(fontSize = size).touched() else el
+    }
+
+    /** Set text alignment on every selected [Element.Text]. */
+    fun setSelectedTextAlignment(
+        elements: List<Element>,
+        ids: Set<String>,
+        alignment: TextAlignment,
+    ): List<Element> = elements.map { el ->
+        if (el.id in ids && el is Element.Text) el.copy(alignment = alignment).touched() else el
+    }
+
+    /** Set font family key on every selected [Element.Text]. */
+    fun setSelectedFontFamily(
+        elements: List<Element>,
+        ids: Set<String>,
+        fontFamilyKey: String,
+    ): List<Element> = elements.map { el ->
+        if (el.id in ids && el is Element.Text) el.copy(fontFamilyKey = fontFamilyKey).touched() else el
     }
 
     // Image operations
@@ -267,6 +350,7 @@ class UseCase {
                 is Element.Path -> el.copy(zIndex = next++).touched()
                 is Element.Shape -> el.copy(zIndex = next++).touched()
                 is Element.Image -> el.copy(zIndex = next++).touched()
+                is Element.Text -> el.copy(zIndex = next++).touched()
             } else el
         }
     }
@@ -285,6 +369,7 @@ class UseCase {
                 is Element.Path -> el.copy(zIndex = newZ).touched()
                 is Element.Shape -> el.copy(zIndex = newZ).touched()
                 is Element.Image -> el.copy(zIndex = newZ).touched()
+                is Element.Text -> el.copy(zIndex = newZ).touched()
             } else el
         }
     }
@@ -301,6 +386,9 @@ class UseCase {
             // Images have no stroke — recolor is a no-op rather than an error,
             // so multi-selecting a mix of shapes and images still works.
             is Element.Image -> el
+            // Text reuses the "stroke color" intent as a unified tint so the
+            // existing color picker recolors text without a separate intent.
+            is Element.Text -> el.copy(color = color).touched()
         }
     }
 
@@ -318,6 +406,7 @@ class UseCase {
             is Element.Shape -> el.copy(fillColor = color).touched()
             is Element.Path -> el
             is Element.Image -> el
+            is Element.Text -> el
         }
     }
 
@@ -334,6 +423,7 @@ class UseCase {
             is Element.Shape -> el.copy(strokeEnabled = enabled).touched()
             is Element.Path -> el
             is Element.Image -> el
+            is Element.Text -> el
         }
     }
 
@@ -354,6 +444,7 @@ class UseCase {
             ).touched()
             is Element.Shape -> el.copy(strokeWidth = width).touched()
             is Element.Image -> el
+            is Element.Text -> el
         }
     }
 
@@ -383,6 +474,7 @@ class UseCase {
             is Element.Shape -> el.copy(strokeStyle = style).touched()
             is Element.Path -> el.copy(strokeStyle = style).touched()
             is Element.Image -> el
+            is Element.Text -> el
         }
     }
 
@@ -407,6 +499,10 @@ class UseCase {
             ).touched()
             is Element.Shape -> el.copy(points = newPoints).touched()
             is Element.Image -> el.copy(points = newPoints).touched()
+            // Text geometry is topLeft + wrapWidth + measuredHeight; the
+            // point-list intent doesn't apply. Treat as a no-op so multi-
+            // selecting LINE / ARROW + Text still works.
+            is Element.Text -> el
         }
     }
 
@@ -529,6 +625,14 @@ private const val MIN_PEN_POINT_DIST_SQ: Float = 1f
  * roughly notebook-size on a 1× canvas — still readable, easy to grow.
  */
 private const val MAX_PLACED_EXTENT: Float = 600f
+
+/**
+ * Default world-pixel width for a freshly inserted text block. Wide enough to
+ * fit a typical sentence at default font size without immediate re-wrap, and
+ * narrow enough that the wrap box's edge-handle is visible inside the
+ * default-zoom viewport.
+ */
+private const val DEFAULT_TEXT_BOX_WIDTH: Float = 240f
 
 /**
  * Slop, in world pixels, applied to a bindable shape's AABB when deciding

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
@@ -1,5 +1,6 @@
 package io.ak1.drawbox.presentation.reducer
 
+import io.ak1.drawbox.domain.model.Element
 import io.ak1.drawbox.domain.model.HISTORY_CAP
 import io.ak1.drawbox.domain.model.Intent
 import io.ak1.drawbox.domain.model.Mode
@@ -51,6 +52,61 @@ class Reducer(
                 intent.newPoint, state.elements, intent.pressure,
             ),
         )
+        is Intent.InsertText -> {
+            val newText = useCase.insertText(
+                intent.text,
+                intent.position,
+                intent.fontSize,
+                intent.fontFamilyKey,
+                intent.alignment,
+                intent.color,
+            )
+            state.snapshot().copy(
+                elements = useCase.addElement(newText, state.elements),
+            )
+        }
+        is Intent.UpdateText -> state.snapshot().copy(
+            elements = useCase.updateText(state.elements, intent.id, intent.text),
+        )
+        is Intent.SetSelectedFontSize -> {
+            if (state.selectedIds.isEmpty()) state
+            else state.snapshot().copy(
+                elements = useCase.setSelectedFontSize(
+                    state.elements, state.selectedIds, intent.size,
+                ),
+            )
+        }
+        is Intent.SetSelectedTextAlignment -> {
+            if (state.selectedIds.isEmpty()) state
+            else state.snapshot().copy(
+                elements = useCase.setSelectedTextAlignment(
+                    state.elements, state.selectedIds, intent.alignment,
+                ),
+            )
+        }
+        is Intent.SetSelectedFontFamily -> {
+            if (state.selectedIds.isEmpty()) state
+            else state.snapshot().copy(
+                elements = useCase.setSelectedFontFamily(
+                    state.elements, state.selectedIds, intent.fontFamilyKey,
+                ),
+            )
+        }
+        is Intent.SyncTextMeasuredHeight -> {
+            // Short-circuit on no-op so identical layouts in successive
+            // frames don't generate State copies (recompositions, listener
+            // wakeups, sync-layer chatter). The 0.5px threshold matches the
+            // renderer's drift gate.
+            val target = state.elements.firstOrNull { it.id == intent.id } as? Element.Text
+            if (target == null ||
+                kotlin.math.abs(target.measuredHeight - intent.height) < 0.5f
+            ) state
+            else state.copy(
+                elements = useCase.syncTextMeasuredHeight(
+                    state.elements, intent.id, intent.height,
+                ),
+            )
+        }
         is Intent.InsertImage -> {
             val newImage = useCase.insertImage(
                 intent.bytes,
@@ -81,6 +137,9 @@ class Reducer(
         is Intent.SetStrokeWidth -> state.copy(strokeWidth = intent.width)
         is Intent.SetCornerRadius -> state.copy(currentItemCornerRadius = intent.radius)
         is Intent.SetStrokeStyle -> state.copy(currentItemStrokeStyle = intent.style)
+        is Intent.SetFontSize -> state.copy(currentItemFontSize = intent.size)
+        is Intent.SetFontFamily -> state.copy(currentItemFontFamilyKey = intent.fontFamilyKey)
+        is Intent.SetTextAlignment -> state.copy(currentItemTextAlignment = intent.alignment)
         is Intent.SetOpacity -> state.copy(opacity = intent.opacity)
         is Intent.SetBgColor -> state.copy(bgColor = intent.bgColor)
         is Intent.SetBackgroundPattern -> state.copy(bgPattern = intent.pattern)

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -239,6 +239,68 @@ class DrawBoxController(
         position: Offset = Offset.Zero,
     ) = onIntent(Intent.InsertImage(bytes, position, intrinsicSize))
 
+    /**
+     * Place a plain-text block on the canvas. [text] may be empty — the
+     * sample-app modal-editor flow inserts an empty block first and then
+     * dispatches [updateText] when the user commits content.
+     *
+     * [fontFamilyKey] must be a key registered via [registerFont] or one of
+     * the built-in keys (`sans`, `serif`, `mono`); unknown keys fall back to
+     * `sans` at render time.
+     */
+    fun insertText(
+        text: String,
+        position: Offset = Offset.Zero,
+        fontSize: Float = 24f,
+        fontFamilyKey: String = io.ak1.drawbox.domain.model.DEFAULT_FONT_FAMILY_KEY,
+        alignment: io.ak1.drawbox.domain.model.TextAlignment =
+            io.ak1.drawbox.domain.model.TextAlignment.LEFT,
+        color: Color = Color.Black,
+    ) = onIntent(
+        Intent.InsertText(text, position, fontSize, fontFamilyKey, alignment, color),
+    )
+
+    /** Replace the text content of an existing [io.ak1.drawbox.domain.model.Element.Text]. */
+    fun updateText(id: String, text: String) =
+        onIntent(Intent.UpdateText(id, text))
+
+    /**
+     * Register a custom font family the SDK can resolve by [key] when
+     * rendering [io.ak1.drawbox.domain.model.Element.Text] elements. Built-in
+     * keys (`sans`, `serif`, `mono`) ship with the SDK and don't need
+     * registration; calling this is for adding host-provided typefaces.
+     *
+     * The registry is in-memory only — the host re-registers on app launch.
+     */
+    fun registerFont(
+        key: String,
+        family: androidx.compose.ui.text.font.FontFamily,
+    ) {
+        io.ak1.drawbox.text.FontRegistry.register(key, family)
+    }
+
+    /** Set the font size of every selected text element. */
+    fun setSelectionFontSize(size: Float) =
+        onIntent(Intent.SetSelectedFontSize(size))
+
+    /** Set the alignment of every selected text element. */
+    fun setSelectionTextAlignment(alignment: io.ak1.drawbox.domain.model.TextAlignment) =
+        onIntent(Intent.SetSelectedTextAlignment(alignment))
+
+    /** Set the font family key of every selected text element. */
+    fun setSelectionFontFamily(fontFamilyKey: String) =
+        onIntent(Intent.SetSelectedFontFamily(fontFamilyKey))
+
+    /** Default font size for the next [Intent.InsertText]. */
+    fun setFontSize(size: Float) = onIntent(Intent.SetFontSize(size))
+
+    /** Default font family key for the next [Intent.InsertText]. */
+    fun setFontFamily(fontFamilyKey: String) = onIntent(Intent.SetFontFamily(fontFamilyKey))
+
+    /** Default alignment for the next [Intent.InsertText]. */
+    fun setTextAlignment(alignment: io.ak1.drawbox.domain.model.TextAlignment) =
+        onIntent(Intent.SetTextAlignment(alignment))
+
     /** Undo the last drawing action */
     fun undo() = onIntent(Intent.Undo)
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/text/FontRegistry.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/text/FontRegistry.kt
@@ -1,0 +1,51 @@
+package io.ak1.drawbox.text
+
+import androidx.compose.ui.text.font.FontFamily
+import io.ak1.drawbox.domain.model.BuiltinFontFamilyKeys
+import io.ak1.drawbox.domain.model.DEFAULT_FONT_FAMILY_KEY
+
+/**
+ * In-memory registry mapping a [String] key (as stored on
+ * [io.ak1.drawbox.domain.model.Element.Text.fontFamilyKey]) to a
+ * Compose [FontFamily]. The registry is process-wide and intentionally
+ * non-persistent — hosts re-register their custom families on app launch,
+ * which keeps the SDK free of font-asset bundling and version skew.
+ *
+ * Three built-in keys (`sans`, `serif`, `mono`) are pre-registered to
+ * Compose's platform defaults so an embedder that does nothing special
+ * still gets readable text.
+ *
+ * Lookups for unknown keys fall back to `sans` and log a hint (the OSS
+ * SDK doesn't bundle a logger so the warning is best-effort via `println`).
+ */
+object FontRegistry {
+    private val families: MutableMap<String, FontFamily> = mutableMapOf(
+        BuiltinFontFamilyKeys.SANS to FontFamily.SansSerif,
+        BuiltinFontFamilyKeys.SERIF to FontFamily.Serif,
+        BuiltinFontFamilyKeys.MONO to FontFamily.Monospace,
+    )
+
+    fun register(key: String, family: FontFamily) {
+        families[key] = family
+    }
+
+    /**
+     * Resolve [key] to a [FontFamily]. Falls back to the registered default
+     * ([DEFAULT_FONT_FAMILY_KEY]) when [key] is unknown. Returns
+     * [FontFamily.SansSerif] when even the default is missing — that's only
+     * possible if a host explicitly removed it (e.g. via [clear]).
+     */
+    fun resolve(key: String): FontFamily {
+        families[key]?.let { return it }
+        println("[DrawBox] Font family key '$key' not registered; falling back to '$DEFAULT_FONT_FAMILY_KEY'.")
+        return families[DEFAULT_FONT_FAMILY_KEY] ?: FontFamily.SansSerif
+    }
+
+    /** Returns every currently registered key. Useful for picker UIs. */
+    fun keys(): Set<String> = families.keys.toSet()
+
+    /** Test-only: drop every registration including the built-ins. */
+    internal fun clear() {
+        families.clear()
+    }
+}

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/text/InlineTextEditor.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/text/InlineTextEditor.kt
@@ -1,0 +1,131 @@
+package io.ak1.drawbox.text
+
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import io.ak1.drawbox.domain.model.Element
+import io.ak1.drawbox.domain.model.TextAlignment
+import io.ak1.drawbox.domain.model.Viewport
+
+/**
+ * Built-in inline text editor for [Element.Text]. Renders as the element
+ * it edits — same font family, font size, alignment, color, wrap width, and
+ * position — so the caret is the only visible "you are editing" affordance.
+ * The element underneath is expected to be hidden by the host via
+ * [io.ak1.drawbox.DrawBox]'s `hiddenElementIds` parameter to avoid ghosting.
+ *
+ * Embedders are free to ignore this composable and ship their own editor
+ * (modal, side-panel, IME-driven, etc.) — the SDK's `InsertText` /
+ * `UpdateText` intents and `Element.Text` model don't depend on it. This
+ * exists as the "drop-in" path for hosts that don't want to write one.
+ *
+ * ### Pixel fidelity with the renderer
+ *
+ * The implementation deliberately mirrors the SDK's text rendering path:
+ *
+ * - `TextStyle.fontSize` is `(element.fontSize × viewport.scale).sp`
+ *   *directly* — NOT `.toSp()`. `Density.toSp(Float)` treats its input as
+ *   dp-equivalent and divides by `fontScale`; feeding it screen pixels
+ *   would shrink the editor by `1 / fontScale` whenever the system text
+ *   scale is non-unit. Going `.sp` direct routes editor and renderer
+ *   through the same final conversion (`fontSize × density × fontScale`),
+ *   so on-screen pixels match across any density / fontScale /
+ *   viewport.scale combination.
+ * - `width = element.wrapWidth × viewport.scale` (no `fillMaxWidth`) — the
+ *   field wraps at the same point as `TextMeasurer.measure(constraints =
+ *   Constraints(maxWidth = wrapWidth))`.
+ * - `lineHeight` is left unspecified in both editor and renderer so line
+ *   breaks land identically.
+ * - Position via `Modifier.offset { IntOffset(...) }` re-reads
+ *   [Viewport.worldToScreen] each composition — pan / zoom while editing
+ *   reposition smoothly.
+ *
+ * ### State
+ *
+ * [draft] / [onDraftChange] are hoisted so the host's outside-tap overlay
+ * can read the current draft when committing, without coordinating focus
+ * events. Recommended host flow:
+ *
+ * 1. When the user enters TEXT mode and taps, the SDK dispatches
+ *    `Intent.InsertText("")` from the canvas tap handler.
+ * 2. Host detects a new empty `Element.Text` (e.g. via a
+ *    `LaunchedEffect(state.elements)`), records its id as `editingId`,
+ *    seeds `draft = ""`.
+ * 3. Host passes `hiddenElementIds = setOf(editingId)` to `DrawBox`.
+ * 4. Host renders this composable + a full-screen click-catcher overlay.
+ *    Tapping outside the field triggers commit (`updateText(id, draft)`
+ *    if non-empty, else `Intent.DeleteElement(id)`).
+ *
+ * ### Font family
+ *
+ * The family is resolved internally from [FontRegistry] via
+ * [Element.Text.fontFamilyKey]. Hosts that want a different family
+ * register a new key on app launch and set
+ * [io.ak1.drawbox.presentation.viewmodel.DrawBoxController.setFontFamily]
+ * before the next insert.
+ *
+ * @param element the text element being edited.
+ * @param viewport the current camera transform — used to project the
+ *   element's world position into screen space and to scale font size.
+ * @param draft current edit content. Hosted by the caller so a sibling
+ *   "outside-tap commits" overlay can read the latest value at any time.
+ * @param onDraftChange fires on every keystroke with the new draft.
+ */
+@Composable
+fun InlineTextEditor(
+    element: Element.Text,
+    viewport: Viewport,
+    draft: String,
+    onDraftChange: (String) -> Unit,
+) {
+    val screenTopLeft = viewport.worldToScreen(element.topLeft)
+    val screenWidth = element.wrapWidth * viewport.scale
+
+    val widthDp = with(androidx.compose.ui.platform.LocalDensity.current) {
+        screenWidth.toDp()
+    }
+    val fontSizeSp = (element.fontSize * viewport.scale).sp
+
+    val focusRequester = remember(element.id) { FocusRequester() }
+    LaunchedEffect(element.id) {
+        runCatching { focusRequester.requestFocus() }
+    }
+
+    BasicTextField(
+        value = draft,
+        onValueChange = onDraftChange,
+        textStyle = TextStyle(
+            fontSize = fontSizeSp,
+            fontFamily = FontRegistry.resolve(element.fontFamilyKey),
+            textAlign = when (element.alignment) {
+                TextAlignment.LEFT -> TextAlign.Left
+                TextAlignment.CENTER -> TextAlign.Center
+                TextAlignment.RIGHT -> TextAlign.Right
+            },
+            color = element.color,
+        ),
+        cursorBrush = SolidColor(element.color),
+        modifier = Modifier
+            // Editor sits in the topmost compositional layer of the host
+            // tree — `zIndex(10f)` puts it above the recommended click-
+            // catcher overlay (z 9) and far above the canvas (z 0).
+            .zIndex(10f)
+            .offset {
+                IntOffset(screenTopLeft.x.toInt(), screenTopLeft.y.toInt())
+            }
+            .width(widthDp)
+            .focusRequester(focusRequester),
+    )
+}

--- a/shared/src/commonMain/composeResources/drawable/letter_t.xml
+++ b/shared/src/commonMain/composeResources/drawable/letter_t.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,4l12,0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,4l0,16"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.unit.dp
 import io.ak1.drawbox.DrawBox
 import io.ak1.drawbox.domain.model.Element
@@ -39,6 +40,7 @@ import io.ak1.drawboxsample.ui.components.BgPatternPreset
 import io.ak1.drawboxsample.ui.components.ColorPickerDialog
 import io.ak1.drawboxsample.ui.components.ContextBar
 import io.ak1.drawboxsample.ui.components.ControlsBar
+import io.ak1.drawbox.text.InlineTextEditor
 import io.ak1.drawboxsample.ui.components.SettingsDrawer
 import io.ak1.drawboxsample.ui.components.TopRightControls
 import io.ak1.drawboxsample.ui.components.ZoomToolbar
@@ -111,8 +113,15 @@ fun HomeScreen(
     val selectedDrawables = state.elements.filter { it.id in state.selectedIds }
     val isShapeMode =
         state.mode == Mode.PEN || state.mode == Mode.RECTANGLE || state.mode == Mode.CIRCLE || state.mode == Mode.TRIANGLE || state.mode == Mode.ARROW || state.mode == Mode.LINE
+    val isTextMode = state.mode == Mode.TEXT
     val hasSelection = selectedDrawables.isNotEmpty()
-    val showShapeConfig = isShapeMode || hasSelection
+    // Shape-stroke chips apply to shapes/paths. Hide them in TEXT mode
+    // (the selection is text, or there's no selection — neither needs
+    // stroke style/width).
+    val selectedHasStrokeable = selectedDrawables.any {
+        it is Element.Shape || it is Element.Path
+    }
+    val showShapeStroke = isShapeMode || selectedHasStrokeable
     val showCornerRadius = state.mode == Mode.RECTANGLE || state.mode == Mode.TRIANGLE || selectedRoundable.isNotEmpty()
     val currentRadius = if (selectedRoundable.isNotEmpty()) (selectedRoundable.first() as Element.Shape).cornerRadius
     else state.currentItemCornerRadius
@@ -124,6 +133,7 @@ fun HomeScreen(
     val currentShapeColor = when (val first = selectedDrawables.firstOrNull()) {
         is Element.Shape -> first.strokeColor
         is Element.Path -> first.strokeColor
+        is Element.Text -> first.color
         else -> state.strokeColor
     }
     val currentStrokeWidth = when (val first = selectedDrawables.firstOrNull()) {
@@ -140,6 +150,21 @@ fun HomeScreen(
     val currentFillColor = selectedShapes.firstOrNull()?.fillColor
     val currentStrokeEnabled = selectedShapes.firstOrNull()?.strokeEnabled ?: true
 
+    // Text controls — surfaced in TEXT mode (pre-configure the next insert)
+    // OR when a single Text element is selected (edit existing). Multi-text
+    // editing is out of scope for v1 — the ContextBar would have to merge
+    // possibly-conflicting style values.
+    val selectedTexts = selectedDrawables.filterIsInstance<Element.Text>()
+    val singleSelectedText = selectedTexts.singleOrNull()?.takeIf { selectedDrawables.size == 1 }
+    val showTextControls = isTextMode || singleSelectedText != null
+    val showEditText = singleSelectedText != null
+    // Current values follow the selected element when present; otherwise
+    // fall back to the State defaults the next insert will use.
+    val currentFontSize = singleSelectedText?.fontSize ?: state.currentItemFontSize
+    val currentTextAlignment = singleSelectedText?.alignment ?: state.currentItemTextAlignment
+    val currentFontFamilyKey = singleSelectedText?.fontFamilyKey ?: state.currentItemFontFamilyKey
+    val fontFamilyKeys = io.ak1.drawbox.text.FontRegistry.keys()
+
     // Drawer + bg-pattern state.
     var drawerOpen by remember { mutableStateOf(false) }
     var replayOpen by remember { mutableStateOf(false) }
@@ -150,6 +175,35 @@ fun HomeScreen(
     // auto-collapse of floating bars so they get out of the way during drawing.
     var isDrawingActive by remember { mutableStateOf(false) }
     val barsExpanded = !isDrawingActive
+
+    // TEXT mode flow: DrawBox dispatches Intent.InsertText("") on tap. We
+    // detect the newly inserted empty Text element here and open the inline
+    // editor. The editor renders as the element-to-be (no border, no Done
+    // button) and is dismissed by tapping anywhere outside, which routes
+    // through a full-screen overlay below. Empty commits delete the element.
+    var editingTextId by remember { mutableStateOf<String?>(null) }
+    // Draft is hoisted up here so the outside-tap overlay can read the
+    // latest value when committing — no focus-event juggling needed.
+    var editDraft by remember { mutableStateOf("") }
+    LaunchedEffect(state.elements) {
+        if (editingTextId != null) return@LaunchedEffect
+        val last = state.elements.lastOrNull()
+        if (last is Element.Text && last.text.isEmpty()) {
+            editingTextId = last.id
+            editDraft = ""
+        }
+    }
+    // Helper: commit the current draft for the editing element. Empty drafts
+    // delete the element so an invisible wrap box never lingers.
+    fun commitTextEdit() {
+        val id = editingTextId ?: return
+        if (editDraft.isEmpty()) {
+            viewModel.onIntent(io.ak1.drawbox.domain.model.Intent.DeleteElement(id))
+        } else {
+            viewModel.updateText(id, editDraft)
+        }
+        editingTextId = null
+    }
 
     // Apply background pattern to the canvas. Tinted against onSurface so the
     // same drawable reads on both light and dark canvases.
@@ -182,6 +236,10 @@ fun HomeScreen(
                     }
                 },
             showGrid = showGrid.value,
+            // While the inline editor is open over a text element, tell the
+            // SDK to skip both the element render and its selection chrome
+            // so the editor's frame is the only one visible (no ghosting).
+            hiddenElementIds = editingTextId?.let { setOf(it) } ?: emptySet(),
         )
         BoxWithConstraints(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
             val isNarrow = maxWidth < 600.dp
@@ -189,19 +247,28 @@ fun HomeScreen(
 
             // Top-right unified context bar — merges shape config + selection
             // actions into one pill. Rendered only when there's something to show.
-            if (showShapeConfig || hasSelection) {
+            val barVisible = showShapeStroke || showCornerRadius || showFill ||
+                showStrokeToggle || showTextControls || hasSelection
+            if (barVisible) {
                 ContextBar(
                     isShapeMode = isShapeMode,
                     hasSelection = hasSelection,
+                    showShapeStroke = showShapeStroke,
                     showCornerRadius = showCornerRadius,
                     showFill = showFill,
                     showStrokeToggle = showStrokeToggle,
+                    showTextControls = showTextControls,
+                    showEditText = showEditText,
                     currentColor = currentShapeColor,
                     currentFillColor = currentFillColor,
                     currentStrokeEnabled = currentStrokeEnabled,
                     currentStrokeStyle = currentStrokeStyle,
                     currentStrokeWidth = currentStrokeWidth,
                     currentCornerRadius = currentRadius,
+                    currentFontSize = currentFontSize,
+                    currentTextAlignment = currentTextAlignment,
+                    currentFontFamilyKey = currentFontFamilyKey,
+                    fontFamilyKeys = fontFamilyKeys,
                     expanded = barsExpanded,
                     onColorChange = { color ->
                         if (hasSelection) viewModel.setSelectionColor(color)
@@ -220,6 +287,27 @@ fun HomeScreen(
                     onCornerRadiusChange = { r ->
                         if (selectedRoundable.isNotEmpty()) viewModel.setSelectionCornerRadius(r)
                         else viewModel.setCornerRadius(r)
+                    },
+                    onFontSizeChange = { size ->
+                        // Selected text → mutate that element. TEXT mode with
+                        // no selection → mutate the State default so the next
+                        // insert picks it up.
+                        if (singleSelectedText != null) viewModel.setSelectionFontSize(size)
+                        else viewModel.setFontSize(size)
+                    },
+                    onTextAlignmentChange = { align ->
+                        if (singleSelectedText != null) viewModel.setSelectionTextAlignment(align)
+                        else viewModel.setTextAlignment(align)
+                    },
+                    onFontFamilyChange = { key ->
+                        if (singleSelectedText != null) viewModel.setSelectionFontFamily(key)
+                        else viewModel.setFontFamily(key)
+                    },
+                    onEditText = {
+                        singleSelectedText?.let { target ->
+                            editingTextId = target.id
+                            editDraft = target.text
+                        }
                     },
                     onBringToFront = { viewModel.bringSelectionToFront() },
                     onSendToBack = { viewModel.sendSelectionToBack() },
@@ -327,6 +415,49 @@ fun HomeScreen(
                 bgColor = state.bgColor,
                 onClose = { replayOpen = false },
             )
+        }
+
+        // Inline text editor + outside-tap commit overlay. The editor itself
+        // renders frameless — same font/size/alignment/color as the element
+        // it'll become, no border, no Done button. The full-screen overlay
+        // below it captures any tap outside the field and triggers commit.
+        // Empty commits delete the element.
+        val editingId = editingTextId
+        if (editingId != null) {
+            val target = state.elements.firstOrNull { it.id == editingId } as? Element.Text
+            if (target == null) {
+                editingTextId = null
+            } else {
+                // Click-catcher: positioned over the canvas + toolbars so any
+                // outside tap routes through here. Transparent — the canvas
+                // remains visible underneath. Blocks ContextBar interaction
+                // during edit by design (no mid-edit style changes); the
+                // user picks style first, then types.
+                androidx.compose.foundation.layout.Box(
+                    modifier = Modifier
+                        // Layer 2: above the canvas + toolbars (which sit at
+                        // the default z 0), below the editor (z 10).
+                        .zIndex(9f)
+                        .fillMaxSize()
+                        .pointerInput(editingId) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    if (event.type == PointerEventType.Press) {
+                                        commitTextEdit()
+                                        break
+                                    }
+                                }
+                            }
+                        },
+                )
+                InlineTextEditor(
+                    element = target,
+                    viewport = state.viewport,
+                    draft = editDraft,
+                    onDraftChange = { editDraft = it },
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ContextBar.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ContextBar.kt
@@ -11,11 +11,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FlipToBack
 import androidx.compose.material.icons.filled.FlipToFront
+import androidx.compose.material.icons.automirrored.filled.FormatAlignLeft
+import androidx.compose.material.icons.automirrored.filled.FormatAlignRight
+import androidx.compose.material.icons.filled.FormatAlignCenter
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.Icon
@@ -45,6 +50,13 @@ private const val RadiusRound = 40f
 private val StrokeWidthOptions = listOf(5f, 10f, 15f, 20f)
 
 /**
+ * World-pixel font-size presets surfaced by the text submenu. Picked to span
+ * caption (12) → display (48) at sensible intervals; intermediate values are
+ * available programmatically via [Intent.SetSelectedFontSize].
+ */
+private val TextSizePresets = listOf(12f, 16f, 20f, 24f, 32f, 48f)
+
+/**
  * Top-right contextual pill built on [ExpandableFloatingToolbar]. Mirrors the
  * bottom NavBar pattern: each slot is a single icon, and slots that have
  * children open a vertical sub-bar below the icon when tapped.
@@ -65,15 +77,22 @@ private val StrokeWidthOptions = listOf(5f, 10f, 15f, 20f)
 fun ContextBar(
     isShapeMode: Boolean,
     hasSelection: Boolean,
+    showShapeStroke: Boolean,
     showCornerRadius: Boolean,
     showFill: Boolean,
     showStrokeToggle: Boolean,
+    showTextControls: Boolean,
+    showEditText: Boolean,
     currentColor: Color,
     currentFillColor: Color?,
     currentStrokeEnabled: Boolean,
     currentStrokeStyle: StrokeStyle,
     currentStrokeWidth: Float,
     currentCornerRadius: Float,
+    currentFontSize: Float,
+    currentTextAlignment: io.ak1.drawbox.domain.model.TextAlignment,
+    currentFontFamilyKey: String,
+    fontFamilyKeys: Set<String>,
     expanded: Boolean,
     onColorChange: (Color) -> Unit,
     onFillColorChange: (Color?) -> Unit,
@@ -81,14 +100,20 @@ fun ContextBar(
     onStrokeStyleChange: (StrokeStyle) -> Unit,
     onStrokeWidthChange: (Float) -> Unit,
     onCornerRadiusChange: (Float) -> Unit,
+    onFontSizeChange: (Float) -> Unit,
+    onTextAlignmentChange: (io.ak1.drawbox.domain.model.TextAlignment) -> Unit,
+    onFontFamilyChange: (String) -> Unit,
+    onEditText: () -> Unit,
     onBringToFront: () -> Unit,
     onSendToBack: () -> Unit,
     onDelete: () -> Unit,
     onClear: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val showConfig = isShapeMode || hasSelection
-    if (!showConfig && !hasSelection) return
+    // The bar is visible whenever any of its slots have something to show.
+    val anySlot = showShapeStroke || showCornerRadius || showFill ||
+        showStrokeToggle || showTextControls || hasSelection
+    if (!anySlot) return
 
     var showColorDialog by remember { mutableStateOf(false) }
     if (showColorDialog) {
@@ -168,6 +193,86 @@ fun ContextBar(
             )
         }
 
+        if (showTextControls) {
+            if (showEditText) {
+                add(
+                    FloatingMenuItem(
+                        id = "text-edit",
+                        icon = { _ ->
+                            Icon(
+                                imageVector = androidx.compose.material.icons.Icons.Filled.Edit,
+                                contentDescription = "Edit text",
+                                tint = active,
+                            )
+                        },
+                        onClick = onEditText,
+                    ),
+                )
+            }
+            add(
+                FloatingMenuItem(
+                    id = "text-size",
+                    icon = { _ -> TextSizeIcon(size = currentFontSize, color = active) },
+                    children = TextSizePresets.map { value ->
+                        FloatingMenuItem(
+                            id = "text-size-${value.toInt()}",
+                            isActive = kotlin.math.abs(currentFontSize - value) < 0.5f,
+                            icon = { isActive ->
+                                TextSizeIcon(
+                                    size = value,
+                                    color = isActive.getActiveColor(),
+                                )
+                            },
+                            onClick = { onFontSizeChange(value) },
+                        )
+                    },
+                ),
+            )
+            add(
+                FloatingMenuItem(
+                    id = "text-align",
+                    icon = { _ ->
+                        TextAlignmentIcon(
+                            alignment = currentTextAlignment,
+                            color = active,
+                        )
+                    },
+                    children = io.ak1.drawbox.domain.model.TextAlignment.entries.map { align ->
+                        FloatingMenuItem(
+                            id = "text-align-${align.name.lowercase()}",
+                            isActive = align == currentTextAlignment,
+                            icon = { isActive ->
+                                TextAlignmentIcon(
+                                    alignment = align,
+                                    color = isActive.getActiveColor(),
+                                )
+                            },
+                            onClick = { onTextAlignmentChange(align) },
+                        )
+                    },
+                ),
+            )
+            add(
+                FloatingMenuItem(
+                    id = "text-family",
+                    icon = { _ -> FontFamilyLabel(key = currentFontFamilyKey, color = active) },
+                    children = fontFamilyKeys.sorted().map { key ->
+                        FloatingMenuItem(
+                            id = "text-family-$key",
+                            isActive = key == currentFontFamilyKey,
+                            icon = { isActive ->
+                                FontFamilyLabel(
+                                    key = key,
+                                    color = isActive.getActiveColor(),
+                                )
+                            },
+                            onClick = { onFontFamilyChange(key) },
+                        )
+                    },
+                ),
+            )
+        }
+
         if (showFill) {
             add(
                 FloatingMenuItem(
@@ -195,7 +300,7 @@ fun ContextBar(
             )
         }
 
-        if (showConfig) {
+        if (showShapeStroke) {
             add(
                 FloatingMenuItem(
                     id = "stroke",
@@ -238,7 +343,7 @@ fun ContextBar(
             )
         }
 
-        if (showConfig && showCornerRadius) {
+        if (showCornerRadius) {
             add(
                 FloatingMenuItem(
                     id = "corner",
@@ -476,6 +581,62 @@ private fun SizeDot(size: Float, isSelected: Boolean, color: Color) {
 
         )
     }
+}
+
+/**
+ * Glyph-on-a-chip for a font-size preset. The glyph itself scales with
+ * [size] (clamped to a chip-friendly range) so the chip visually reads as
+ * "small" / "medium" / "huge" without the user having to read a number.
+ */
+@Composable
+private fun TextSizeIcon(size: Float, color: Color) {
+    val display = size.coerceIn(8f, 28f)
+    BasicText(
+        text = "A",
+        style = androidx.compose.ui.text.TextStyle(
+            color = color,
+            fontSize = androidx.compose.ui.unit.TextUnit(display, androidx.compose.ui.unit.TextUnitType.Sp),
+            fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+        ),
+    )
+}
+
+@Composable
+private fun TextAlignmentIcon(
+    alignment: io.ak1.drawbox.domain.model.TextAlignment,
+    color: Color,
+) {
+    val icon = when (alignment) {
+        io.ak1.drawbox.domain.model.TextAlignment.LEFT -> Icons.AutoMirrored.Filled.FormatAlignLeft
+        io.ak1.drawbox.domain.model.TextAlignment.CENTER -> Icons.Filled.FormatAlignCenter
+        io.ak1.drawbox.domain.model.TextAlignment.RIGHT -> Icons.AutoMirrored.Filled.FormatAlignRight
+    }
+    Icon(icon, contentDescription = alignment.name, tint = color)
+}
+
+/**
+ * Three-letter glyph for the family key — written in the family itself so the
+ * chip previews the typeface. Falls back to the key's first three characters
+ * for unknown / custom keys.
+ */
+@Composable
+private fun FontFamilyLabel(key: String, color: Color) {
+    val label = when (key) {
+        "sans" -> "Sa"
+        "serif" -> "Se"
+        "mono" -> "Mo"
+        else -> key.take(2).replaceFirstChar { it.uppercase() }
+    }
+    val family = io.ak1.drawbox.text.FontRegistry.resolve(key)
+    BasicText(
+        text = label,
+        style = androidx.compose.ui.text.TextStyle(
+            color = color,
+            fontFamily = family,
+            fontSize = androidx.compose.ui.unit.TextUnit(14f, androidx.compose.ui.unit.TextUnitType.Sp),
+            fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+        ),
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ControlsBar.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/ControlsBar.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.ak1.drawbox.domain.model.Mode
 import io.ak1.drawboxsample.ui.icons.DrawBoxIcons
@@ -143,6 +142,18 @@ fun ControlsBar(
                 )
             },
             onClick = { onModeSelected(Mode.PEN) },
+        ),
+        FloatingMenuItem(
+            id = "text",
+            isActive = currentMode == Mode.TEXT,
+            icon = { isActive ->
+                Icon(
+                    painter = painterResource(DrawBoxIcons.Text),
+                    contentDescription = "Text",
+                    tint = isActive.getActiveColor(),
+                )
+            },
+            onClick = { onModeSelected(Mode.TEXT) },
         ),
         separator("sep-tools"),
         FloatingMenuItem(

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/icons/DrawBoxIcons.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/icons/DrawBoxIcons.kt
@@ -13,6 +13,7 @@ import drawboxsample.shared.generated.resources.export
 import drawboxsample.shared.generated.resources.file_import
 import drawboxsample.shared.generated.resources.file_type_svg
 import drawboxsample.shared.generated.resources.hand_stop
+import drawboxsample.shared.generated.resources.letter_t
 import drawboxsample.shared.generated.resources.line
 import drawboxsample.shared.generated.resources.palette
 import drawboxsample.shared.generated.resources.png
@@ -43,6 +44,7 @@ object DrawBoxIcons {
     val BorderPill: DrawableResource = Res.drawable.border_corner_pill
     val BorderRounded: DrawableResource = Res.drawable.border_corner_rounded
     val BorderSquare: DrawableResource = Res.drawable.border_corner_square
+    val Text: DrawableResource = Res.drawable.letter_t
 
     // Drawing Tools
     val Ruler: DrawableResource = Res.drawable.ruler


### PR DESCRIPTION
## Summary

- Adds `Element.Text` with two-piece geometry (user-owned `wrapWidth` + renderer-owned `measuredHeight`); renderer dispatches a non-snapshotting `SyncTextMeasuredHeight` when layout drifts.
- `Mode.TEXT` — tap auto-inserts an empty Text with the ContextBar-configured defaults.
- Full intent / controller surface for text styling (`SetSelectedFontSize / TextAlignment / FontFamily` + session-default variants).
- `FontRegistry` seeded with `sans` / `serif` / `mono`; hosts add custom families via `controller.registerFont(key, FontFamily)`.
- `io.ak1.drawbox.text.InlineTextEditor` — drop-in Compose composable that renders frameless over the hidden element (matches the rendered text exactly: same family, size, alignment, color, position). State is hoisted so the host wires its own commit policy.
- JSON + SVG export include text elements.
- `DrawBox` gains `hiddenElementIds: Set<String>` so hosts hide the element being edited under their editor; static-layer cache is now invalidated when an element transitions to hidden.

Closes #74. Follow-ups tracked in #83 (mid-edit styling, double-tap to edit, multi-text selection, rotation verification).

## Test plan

- [ ] Switch to TEXT mode → ContextBar shows size / alignment / family chips. Pick values.
- [ ] Tap canvas → inline editor opens at tap position, styled with the picks. Type → text appears in the field.
- [ ] Tap outside → text commits; field disappears; rendered element matches the editor pixel-for-pixel (same size, position, color).
- [ ] Type nothing + tap outside → element is deleted.
- [ ] In SELECT mode, click a text element → ContextBar shows Edit button + style chips reflecting the element's values. Change size / alignment / family → element updates live.
- [ ] Click Edit on a multi-line block → editor reopens with existing text. Previously-rendered text is hidden (no ghost). Edit, commit → updates land.
- [ ] Resize the box horizontally → text re-wraps, height auto-grows. Vertical-edge drag is a visual no-op (height is auto).
- [ ] Move / rotate via standard handles.
- [ ] Export JSON → re-import → text is byte-identical.
- [ ] Export SVG → opens correctly in Chrome / Inkscape with the right anchor + rotation.
- [ ] Old JSON files (no text fields) still load — Path / Shape / Image elements unaffected.