### PR TITLE
perf: async + downsampled image decode (closes #81)

### DIFF
--- a/DrawBox/src/androidMain/kotlin/io/ak1/drawbox/ImageDecoder.android.kt
+++ b/DrawBox/src/androidMain/kotlin/io/ak1/drawbox/ImageDecoder.android.kt
@@ -8,3 +8,34 @@ actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap? {
     val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return null
     return bitmap.asImageBitmap()
 }
+
+actual fun decodeImageBitmapDownsampled(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? {
+    // Two-pass decode via BitmapFactory.Options:
+    // pass 1 — `inJustDecodeBounds = true` reads only the header so we know
+    // the source dimensions without allocating the full bitmap;
+    // pass 2 — `inSampleSize = N` decodes at 1/N resolution. The result is
+    // never larger than `target × N`, so we pick the smallest power of two
+    // that still fits the target. This keeps memory low and is a single
+    // allocation rather than full-size-then-shrink.
+    val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, boundsOpts)
+    val srcW = boundsOpts.outWidth
+    val srcH = boundsOpts.outHeight
+    if (srcW <= 0 || srcH <= 0) return null
+
+    val widthCap = targetWidth.coerceAtLeast(1)
+    val heightCap = targetHeight.coerceAtLeast(1)
+    var sample = 1
+    while ((srcW / sample) > widthCap || (srcH / sample) > heightCap) {
+        sample *= 2
+    }
+
+    val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOpts)
+        ?: return null
+    return bitmap.asImageBitmap()
+}

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -182,9 +182,11 @@ fun DrawBox(
     // reference actually changes, so finalized strokes don't allocate a new
     // Path every frame during pan/zoom or active drag.
     val pathCache = remember { PathCache() }
-    // Same idea for images: decode once per (id, bytes ref), reuse the
-    // ImageBitmap across frames. Re-decoded only when bytes reference changes.
-    val imageCache = remember { ImageBitmapCache() }
+    // ImageBitmapCache needs a CoroutineScope for off-main-thread decode +
+    // race-safe completion. Tied to the composable's scope so cancellation
+    // and lifecycle follow the canvas. Mip-level keyed so a small placement
+    // doesn't hold a source-resolution bitmap in memory.
+    val imageCache = remember(scope) { ImageBitmapCache(scope) }
     // Text layout cache: lay out each text block once per (id, text, style,
     // wrap width); reuse the result on subsequent frames. TextMeasurer is
     // composition-scoped and must come from rememberTextMeasurer.
@@ -776,7 +778,7 @@ fun DrawBox(
                     }) {
                         orderedElements.forEach { el ->
                             if (el.id !in activeIds && el.id !in hiddenElementIds) {
-                                renderElement(el, pathCache, imageCache, textCache, textMeasurer)
+                                renderElement(el, pathCache, imageCache, textCache, textMeasurer, vp.scale)
                             }
                         }
                     }
@@ -798,7 +800,7 @@ fun DrawBox(
             }) {
                 if (activeIds.isNotEmpty()) {
                     orderedElements.forEach { el ->
-                        if (el.id in activeIds && el.id !in hiddenElementIds) renderElement(el, pathCache, imageCache, textCache, textMeasurer)
+                        if (el.id in activeIds && el.id !in hiddenElementIds) renderElement(el, pathCache, imageCache, textCache, textMeasurer, vp.scale)
                     }
                 }
                 drawSelectionChrome(
@@ -840,7 +842,7 @@ fun DrawBox(
                         translate(vp.offset.x, vp.offset.y)
                         scale(vp.scale, vp.scale, pivot = Offset.Zero)
                     }) {
-                        orderedElements.forEach { renderElement(it, pathCache, imageCache, textCache, textMeasurer) }
+                        orderedElements.forEach { renderElement(it, pathCache, imageCache, textCache, textMeasurer, vp.scale) }
                     }
                 }
                 capturePending = false
@@ -1274,12 +1276,13 @@ private fun DrawScope.renderElement(
     imageCache: ImageBitmapCache? = null,
     textCache: TextLayoutCache? = null,
     textMeasurer: androidx.compose.ui.text.TextMeasurer? = null,
+    viewportScale: Float = 1f,
 ) {
     if (element.rotation == 0f) {
-        renderElementContent(element, pathCache, imageCache, textCache, textMeasurer)
+        renderElementContent(element, pathCache, imageCache, textCache, textMeasurer, viewportScale)
     } else {
         withTransform({ rotate(element.rotation, pivot = element.bounds().center) }) {
-            renderElementContent(element, pathCache, imageCache, textCache, textMeasurer)
+            renderElementContent(element, pathCache, imageCache, textCache, textMeasurer, viewportScale)
         }
     }
 }
@@ -1290,6 +1293,7 @@ private fun DrawScope.renderElementContent(
     imageCache: ImageBitmapCache?,
     textCache: TextLayoutCache?,
     textMeasurer: androidx.compose.ui.text.TextMeasurer?,
+    viewportScale: Float,
 ) {
     when (element) {
         is Element.Path -> {
@@ -1337,7 +1341,7 @@ private fun DrawScope.renderElementContent(
             drawShape(element)
         }
         is Element.Image -> {
-            drawImageElement(element, imageCache)
+            drawImageElement(element, imageCache, viewportScale)
         }
         is Element.Text -> {
             drawTextElement(element, textCache, textMeasurer)
@@ -1395,7 +1399,11 @@ private fun DrawScope.drawTextElement(
  * decode failed), we draw a neutral grey placeholder rectangle so the canvas
  * still reflects the element's footprint and selection chrome remains usable.
  */
-private fun DrawScope.drawImageElement(image: Element.Image, imageCache: ImageBitmapCache?) {
+private fun DrawScope.drawImageElement(
+    image: Element.Image,
+    imageCache: ImageBitmapCache?,
+    viewportScale: Float,
+) {
     if (image.points.size < 2) return
     val topLeft = image.points[0]
     val bottomRight = image.points[1]
@@ -1403,7 +1411,12 @@ private fun DrawScope.drawImageElement(image: Element.Image, imageCache: ImageBi
     val targetH = bottomRight.y - topLeft.y
     if (targetW <= 0f || targetH <= 0f) return
 
-    val bitmap = imageCache?.bitmapFor(image.id, image.bytes)
+    // The cache picks a mip level from the longer dimension in *screen*
+    // pixels — multiplying by viewport.scale gives the renderable size.
+    // A 600 px placement on a HiDPI 2× display at 1.5× zoom decodes at
+    // 1800 px, not 600 (or 4096 source).
+    val targetDimPx = (maxOf(targetW, targetH) * viewportScale).toInt()
+    val bitmap = imageCache?.bitmapFor(image.id, image.bytes, targetDimPx)
         ?: decodeImageBitmap(image.bytes)
     if (bitmap == null) {
         // Visible placeholder so a corrupt / unsupported payload doesn't render

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/Helper.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/Helper.kt
@@ -1,5 +1,6 @@
 package io.ak1.drawbox
 
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -15,6 +16,9 @@ import androidx.compose.ui.unit.sp
 import io.ak1.drawbox.domain.model.Element
 import io.ak1.drawbox.domain.model.TextAlignment
 import io.ak1.drawbox.text.FontRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 
 fun createPath(points: List<Offset>) = Path().apply {
@@ -124,41 +128,135 @@ internal class PathCache {
 }
 
 /**
- * Per-canvas cache of decoded [ImageBitmap] objects for [Element.Image]
- * elements. Decoding a typical 1 MB PNG takes several milliseconds and would
- * otherwise run every frame an image is on screen.
+ * Per-canvas async cache of decoded [ImageBitmap] objects for
+ * [io.ak1.drawbox.domain.model.Element.Image] elements. Decoding a typical
+ * 1 MB PNG takes several milliseconds and used to run on the UI thread
+ * inside the draw pass; this cache moves it onto [Dispatchers.Default] and
+ * stores at mip-level (a power-of-two cap on the longer side) so a small
+ * placement doesn't hold a source-resolution bitmap in memory.
  *
- * Cache hits require BOTH:
- *  - same element id, AND
- *  - the stored bytes reference equals the lookup bytes reference.
+ * ### Lookup contract
  *
- * The second check is what protects us when [Intent.UpdateElement] swaps the
- * payload of an existing id — the new `ByteArray` is a different reference,
- * so we miss and re-decode.
+ * [bitmapFor] is **synchronous and non-blocking** — it returns whatever is
+ * currently in the cache for `id`:
  *
- * Decoding is delegated to [decodeImageBitmap], an `expect`/`actual` that
- * dispatches to the platform's native decoder. Returns `null` when the bytes
- * fail to decode; callers should render a placeholder.
+ * - Exact hit (same `bytes` reference, same mip level): returns the cached
+ *   bitmap.
+ * - Mip-level mismatch (resize): returns the stale lower / higher-res
+ *   bitmap immediately and kicks off a background decode at the new level.
+ * - Bytes mismatch (image replaced): returns null (or stale) and kicks off
+ *   a fresh decode.
+ * - Cold miss: returns null and kicks off the first decode.
+ *
+ * The draw pass should treat null as "show placeholder"; the next
+ * recomposition (triggered by the [androidx.compose.runtime.snapshots.SnapshotStateMap]
+ * write) draws the bitmap.
+ *
+ * ### Race protection
+ *
+ * Each new decode request bumps a monotonic generation counter. When a
+ * decode completes, it only updates the cache if the entry's generation
+ * still matches — so a fast-resize storm that supersedes an in-flight
+ * decode discards the stale result instead of clobbering the newer one.
+ *
+ * ### Mip levels
+ *
+ * The target dimension passed by the caller (typically `placedSize ×
+ * viewport.scale`) is rounded **up** to the next power of two within
+ * `[MIN_MIP_PX, MAX_MIP_PX]`. The decoded bitmap fits inside that cap on
+ * its longer side; the shorter side scales proportionally.
  */
-internal class ImageBitmapCache {
-    private data class Entry(val bytesRef: ByteArray, val bitmap: ImageBitmap?)
-    private val byId = HashMap<String, Entry>()
+internal class ImageBitmapCache(
+    private val scope: CoroutineScope,
+) {
+    private data class Entry(
+        val gen: Long,
+        val bytesRef: ByteArray,
+        val mipLevelPx: Int,
+        val bitmap: ImageBitmap?,
+    )
 
-    fun bitmapFor(id: String, bytes: ByteArray): ImageBitmap? {
+    private val byId = mutableStateMapOf<String, Entry>()
+    private var nextGen: Long = 0L
+
+    /**
+     * Returns the current cached bitmap for [id], starting a background
+     * decode when the key differs from what's stored. The returned value
+     * may be `null` (no bitmap available yet) or a stale-resolution bitmap
+     * from a previous decode — both are valid "show this now" results.
+     *
+     * @param targetDim longer-side target in screen pixels (callers
+     *   typically pass `max(placedWidth, placedHeight) × viewport.scale`).
+     *   Used to pick a mip level; smaller targets get smaller bitmaps.
+     */
+    fun bitmapFor(id: String, bytes: ByteArray, targetDim: Int): ImageBitmap? {
+        val mipLevelPx = mipLevelFor(targetDim)
         val existing = byId[id]
-        if (existing != null && existing.bytesRef === bytes) return existing.bitmap
-        val fresh = decodeImageBitmap(bytes)
-        byId[id] = Entry(bytes, fresh)
-        return fresh
+        if (existing != null &&
+            existing.bytesRef === bytes &&
+            existing.mipLevelPx == mipLevelPx
+        ) {
+            return existing.bitmap
+        }
+
+        // Key changed (bytes swapped, different mip level, or never decoded).
+        // Bump the generation, write a provisional entry with the stale bitmap
+        // (so the renderer can keep showing something), and kick off a fresh
+        // decode in the background. Any prior in-flight decode for the same
+        // id with an older generation will be discarded on completion.
+        val myGen = ++nextGen
+        val staleBitmap = existing?.bitmap
+        byId[id] = Entry(
+            gen = myGen,
+            bytesRef = bytes,
+            mipLevelPx = mipLevelPx,
+            bitmap = staleBitmap,
+        )
+        scope.launch(Dispatchers.Default) {
+            val decoded = decodeImageBitmapDownsampled(bytes, mipLevelPx, mipLevelPx)
+            // Only land the result if our generation is still current. A
+            // newer request that arrived during the decode (fast resize,
+            // new bytes) supersedes us; we drop the result.
+            val current = byId[id]
+            if (current != null && current.gen == myGen) {
+                byId[id] = current.copy(bitmap = decoded)
+            }
+        }
+        return staleBitmap
     }
 
     fun retainOnly(liveIds: Set<String>) {
         if (byId.isEmpty()) return
-        byId.keys.retainAll(liveIds)
+        // SnapshotStateMap.keys.retainAll exists but does an iteration-time
+        // check. Build the drop list first to avoid mutation while iterating.
+        val drop = byId.keys.filter { it !in liveIds }
+        for (id in drop) byId.remove(id)
     }
 
     fun size(): Int = byId.size
+
+    private fun mipLevelFor(targetDim: Int): Int {
+        val clamped = targetDim.coerceIn(MIN_MIP_PX, MAX_MIP_PX)
+        var px = MIN_MIP_PX
+        while (px < clamped) px *= 2
+        return px
+    }
 }
+
+/**
+ * Smallest mip level the cache will produce. A 64×64 thumbnail still fits
+ * in this cap, so we don't decode at sub-thumbnail resolutions.
+ */
+private const val MIN_MIP_PX: Int = 128
+
+/**
+ * Largest mip level. Caps memory at this resolution; placements drawn at
+ * larger sizes will scale up via the GPU rather than the cache holding a
+ * source-resolution bitmap. 2048 px is a reasonable ceiling for canvas
+ * use cases (annotation, whiteboard) — much smaller than the photographic
+ * source size for typical screenshots.
+ */
+private const val MAX_MIP_PX: Int = 2048
 
 /**
  * Per-canvas cache of [TextLayoutResult] entries for [Element.Text]

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/ImageDecoder.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/ImageDecoder.kt
@@ -12,3 +12,28 @@ import androidx.compose.ui.graphics.ImageBitmap
  * - JVM / iOS / WASM: `org.jetbrains.skia.Image.makeFromEncoded(...)` via skiko
  */
 expect fun decodeImageBitmap(bytes: ByteArray): ImageBitmap?
+
+/**
+ * Decode and downsample [bytes] to fit within [targetWidth] × [targetHeight]
+ * while preserving aspect ratio. The returned bitmap's longer side may be
+ * smaller than `targetWidth` / `targetHeight` if the shorter axis hits the
+ * cap first, but never larger.
+ *
+ * Used by the renderer to avoid storing source-resolution bitmaps for
+ * thumbnail-sized placements — a 4096×3000 photo placed at 600×450 stays at
+ * roughly that resolution in memory instead of the full 12 MP.
+ *
+ * Per-platform strategy:
+ * - Android: `BitmapFactory.Options.inSampleSize` — decodes at sub-resolution
+ *   directly, avoiding the full-size intermediate bitmap.
+ * - Skia (JVM / iOS / Web): decode at source, draw scaled into a smaller
+ *   `Surface`, snapshot. The full-size intermediate is short-lived.
+ *
+ * Returns `null` when bytes can't be decoded (matches [decodeImageBitmap]).
+ */
+expect fun decodeImageBitmapDownsampled(
+
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap?

--- a/DrawBox/src/iosMain/kotlin/io/ak1/drawbox/ImageDecoder.ios.kt
+++ b/DrawBox/src/iosMain/kotlin/io/ak1/drawbox/ImageDecoder.ios.kt
@@ -7,3 +7,34 @@ import org.jetbrains.skia.Image
 actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap? = runCatching {
     Image.makeFromEncoded(bytes).toComposeImageBitmap()
 }.getOrNull()
+
+actual fun decodeImageBitmapDownsampled(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? = decodeAndDownsampleSkia(bytes, targetWidth, targetHeight)
+
+private fun decodeAndDownsampleSkia(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? = runCatching {
+    val src = org.jetbrains.skia.Image.makeFromEncoded(bytes)
+    val srcW = src.width.coerceAtLeast(1)
+    val srcH = src.height.coerceAtLeast(1)
+    val capW = targetWidth.coerceAtLeast(1)
+    val capH = targetHeight.coerceAtLeast(1)
+    val scale = minOf(capW.toFloat() / srcW, capH.toFloat() / srcH)
+    if (scale >= 1f) {
+        return@runCatching src.toComposeImageBitmap()
+    }
+    val outW = (srcW * scale).toInt().coerceAtLeast(1)
+    val outH = (srcH * scale).toInt().coerceAtLeast(1)
+    val surface = org.jetbrains.skia.Surface.makeRasterN32Premul(outW, outH)
+    surface.canvas.drawImageRect(
+        src,
+        org.jetbrains.skia.Rect(0f, 0f, srcW.toFloat(), srcH.toFloat()),
+        org.jetbrains.skia.Rect(0f, 0f, outW.toFloat(), outH.toFloat()),
+    )
+    surface.makeImageSnapshot().toComposeImageBitmap()
+}.getOrNull()

--- a/DrawBox/src/jvmMain/kotlin/io/ak1/drawbox/ImageDecoder.jvm.kt
+++ b/DrawBox/src/jvmMain/kotlin/io/ak1/drawbox/ImageDecoder.jvm.kt
@@ -7,3 +7,45 @@ import org.jetbrains.skia.Image
 actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap? = runCatching {
     Image.makeFromEncoded(bytes).toComposeImageBitmap()
 }.getOrNull()
+
+actual fun decodeImageBitmapDownsampled(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? = decodeAndDownsampleSkia(bytes, targetWidth, targetHeight)
+
+/**
+ * Shared skia helper: decode at source resolution, then draw scaled into a
+ * smaller [org.jetbrains.skia.Surface]. The source bitmap is short-lived
+ * (one frame's allocation) — the cache stores only the downsampled output.
+ *
+ * Duplicated across `jvmMain`, `iosMain`, and `wasmJsMain` to avoid a
+ * skia-shared intermediate source set (which needs custom KMP hierarchy
+ * config). Consolidate once the SDK introduces a `skikoMain`-style
+ * intermediate.
+ */
+private fun decodeAndDownsampleSkia(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? = runCatching {
+    val src = org.jetbrains.skia.Image.makeFromEncoded(bytes)
+    val srcW = src.width.coerceAtLeast(1)
+    val srcH = src.height.coerceAtLeast(1)
+    val capW = targetWidth.coerceAtLeast(1)
+    val capH = targetHeight.coerceAtLeast(1)
+    val scale = minOf(capW.toFloat() / srcW, capH.toFloat() / srcH)
+    if (scale >= 1f) {
+        // Don't upscale — return source-resolution bitmap.
+        return@runCatching src.toComposeImageBitmap()
+    }
+    val outW = (srcW * scale).toInt().coerceAtLeast(1)
+    val outH = (srcH * scale).toInt().coerceAtLeast(1)
+    val surface = org.jetbrains.skia.Surface.makeRasterN32Premul(outW, outH)
+    surface.canvas.drawImageRect(
+        src,
+        org.jetbrains.skia.Rect(0f, 0f, srcW.toFloat(), srcH.toFloat()),
+        org.jetbrains.skia.Rect(0f, 0f, outW.toFloat(), outH.toFloat()),
+    )
+    surface.makeImageSnapshot().toComposeImageBitmap()
+}.getOrNull()

--- a/DrawBox/src/webMain/kotlin/io/ak1/drawbox/ImageDecoder.web.kt
+++ b/DrawBox/src/webMain/kotlin/io/ak1/drawbox/ImageDecoder.web.kt
@@ -14,3 +14,34 @@ import org.jetbrains.skia.Image
 actual fun decodeImageBitmap(bytes: ByteArray): ImageBitmap? = runCatching {
     Image.makeFromEncoded(bytes).toComposeImageBitmap()
 }.getOrNull()
+
+actual fun decodeImageBitmapDownsampled(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? = decodeAndDownsampleSkia(bytes, targetWidth, targetHeight)
+
+private fun decodeAndDownsampleSkia(
+    bytes: ByteArray,
+    targetWidth: Int,
+    targetHeight: Int,
+): ImageBitmap? = runCatching {
+    val src = org.jetbrains.skia.Image.makeFromEncoded(bytes)
+    val srcW = src.width.coerceAtLeast(1)
+    val srcH = src.height.coerceAtLeast(1)
+    val capW = targetWidth.coerceAtLeast(1)
+    val capH = targetHeight.coerceAtLeast(1)
+    val scale = minOf(capW.toFloat() / srcW, capH.toFloat() / srcH)
+    if (scale >= 1f) {
+        return@runCatching src.toComposeImageBitmap()
+    }
+    val outW = (srcW * scale).toInt().coerceAtLeast(1)
+    val outH = (srcH * scale).toInt().coerceAtLeast(1)
+    val surface = org.jetbrains.skia.Surface.makeRasterN32Premul(outW, outH)
+    surface.canvas.drawImageRect(
+        src,
+        org.jetbrains.skia.Rect(0f, 0f, srcW.toFloat(), srcH.toFloat()),
+        org.jetbrains.skia.Rect(0f, 0f, outW.toFloat(), outH.toFloat()),
+    )
+    surface.makeImageSnapshot().toComposeImageBitmap()
+}.getOrNull()


### PR DESCRIPTION
## Summary

Two perf problems with the previous `ImageBitmapCache`:

1. **Decode ran on the UI thread.** A 20 MB PNG hung the first frame for hundreds of ms.
2. **Cache stored at source resolution.** Five 4 MP photos placed at thumbnail size held ~250 MB of bitmaps.

This PR fixes both:

- New `expect fun decodeImageBitmapDownsampled(bytes, targetW, targetH)`. Android uses `BitmapFactory.Options.inSampleSize` so the source-resolution bitmap is never allocated. Skia targets (jvmMain / iosMain / webMain) decode + draw scaled into a smaller `Surface` and snapshot.
- `ImageBitmapCache` takes a `CoroutineScope` and dispatches decodes on `Dispatchers.Default`. `bitmapFor(id, bytes, targetDim)` is synchronous and returns stale-or-null immediately; the SnapshotStateMap update from the completed decode triggers recomposition.
- Generation counter discards stale decode results when fast resize storms supersede them.
- Mip levels are power-of-two in `[128, 2048]` px. Renderer computes target dim as `max(placedW, placedH) × viewport.scale` so HiDPI / high-zoom placements decode at the right resolution.

Closes #81.

## Test plan

- [x] All five SDK targets compile (`android`, `jvm`, `iosArm64`, `iosSimulatorArm64`, `wasmJs`, plus `js` via the shared `webMain` actual).
- [x] `:DrawBox:jvmTest --rerun-tasks` — existing domain tests pass; nothing in the cache touches the reducer / use case layer.
- [ ] Manual: insert a 20 MB PNG on the desktop sample → first frame paints a placeholder; bitmap appears once the background decode lands.
- [ ] Manual: insert five 4 MP photos as thumbnails → heap (via `jconsole` or similar) stays under ~30 MB for the image cache.
- [ ] Manual: scrub-resize a placed image → no stutter; cache mip level shifts and old results get discarded.
- [ ] Manual: replace an image's bytes via `Intent.UpdateElement` → stale bitmap shows briefly while the new one decodes.