### PR TITLE
feat: iOS PHPicker + Cmd/Ctrl+V clipboard paste (closes #79, #80)

### DIFF
--- a/shared/src/androidMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.android.kt
+++ b/shared/src/androidMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.android.kt
@@ -1,0 +1,15 @@
+package io.ak1.drawboxsample.save
+
+import androidx.compose.ui.geometry.Size
+
+/**
+ * Android paste is a no-op in the OSS sample. Touch-screen Android doesn't
+ * have a Cmd/Ctrl+V key flow, and the existing file picker covers the
+ * "insert image" path on this platform. Could be wired to `ClipboardManager`
+ * + `MIMETYPE_TEXT_URILIST` in a follow-up if anyone asks.
+ */
+actual fun pasteImageFromClipboard(
+    onLoaded: (ByteArray, Size) -> Unit,
+) {
+    // intentionally no-op
+}

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.kt
@@ -1,0 +1,33 @@
+package io.ak1.drawboxsample.save
+
+import androidx.compose.ui.geometry.Size
+
+/**
+ * Read a single image from the platform clipboard, if one is present.
+ *
+ * Async because:
+ * - Web's `navigator.clipboard.read()` is Promise-based and the browser
+ *   may prompt for permission on first call.
+ * - Desktop AWT `Toolkit.systemClipboard.getData(DataFlavor.imageFlavor)`
+ *   returns a `BufferedImage` we need to re-encode to PNG bytes on a
+ *   background thread.
+ *
+ * Invokes [onLoaded] on the main thread when an image is found and decoded
+ * to encoded bytes (PNG / JPEG / WebP — whatever the clipboard contains,
+ * re-encoded to PNG on platforms where the clipboard owns a decoded
+ * bitmap). Silently no-ops when:
+ *  - Clipboard is empty.
+ *  - Clipboard holds non-image content (text, files, etc.).
+ *  - Permission is denied (Web) or the clipboard is unavailable.
+ *
+ * Per-platform implementations:
+ * - **JVM (Desktop)**: AWT `Toolkit.systemClipboard` + `DataFlavor.imageFlavor`,
+ *   re-encoded to PNG via `ImageIO.write`.
+ * - **Web (WasmJS / JS)**: `navigator.clipboard.read()` → `ClipboardItem` →
+ *   `getType("image/png")` → blob → bytes.
+ * - **Android / iOS**: no-op (touch-screen platforms don't have a Cmd/Ctrl+V
+ *   flow; covered by drag-drop / native pickers respectively).
+ */
+expect fun pasteImageFromClipboard(
+    onLoaded: (bytes: ByteArray, intrinsicSize: Size) -> Unit,
+)

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -20,6 +20,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -35,6 +42,7 @@ import io.ak1.drawbox.domain.model.bezierMidpoint
 import io.ak1.drawbox.domain.model.bounds
 import io.ak1.drawbox.domain.model.controlPoint
 import io.ak1.drawbox.presentation.viewmodel.rememberDrawBoxController
+import io.ak1.drawboxsample.save.pasteImageFromClipboard
 import io.ak1.drawboxsample.save.rememberImageSaver
 import io.ak1.drawboxsample.ui.components.BgPatternPreset
 import io.ak1.drawboxsample.ui.components.ColorPickerDialog
@@ -234,6 +242,25 @@ fun HomeScreen(
                             }
                         }
                     }
+                }
+                // Cmd/Ctrl+V → paste an image from the system clipboard at
+                // the viewport center. Per-platform clipboard read happens
+                // in pasteImageFromClipboard; on touch platforms the call
+                // is a no-op. Hooked via onPreviewKeyEvent so the SDK's
+                // Space-bar pan handler (which only consumes Space) doesn't
+                // shadow us.
+                .onPreviewKeyEvent { event ->
+                    val isV = event.key == Key.V
+                    val isPaste = event.type == KeyEventType.KeyDown &&
+                        isV &&
+                        (event.isMetaPressed || event.isCtrlPressed)
+                    if (isPaste) {
+                        pasteImageFromClipboard { bytes, intrinsicSize ->
+                            val world = state.viewport.screenToWorld(ScreenCenter)
+                            viewModel.insertImage(bytes, intrinsicSize, world)
+                        }
+                        true
+                    } else false
                 },
             showGrid = showGrid.value,
             // While the inline editor is open over a text element, tell the

--- a/shared/src/iosMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.ios.kt
+++ b/shared/src/iosMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.ios.kt
@@ -1,0 +1,15 @@
+package io.ak1.drawboxsample.save
+
+import androidx.compose.ui.geometry.Size
+
+/**
+ * iOS paste is a no-op in the OSS sample. iOS has a system pasteboard
+ * (`UIPasteboard.general`) that could be wired here, but the natural
+ * insertion path on iOS is the PHPicker (issue #80) — that covers the
+ * screenshot → annotate workflow this issue solves on Desktop / Web.
+ */
+actual fun pasteImageFromClipboard(
+    onLoaded: (ByteArray, Size) -> Unit,
+) {
+    // intentionally no-op
+}

--- a/shared/src/iosMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.ios.kt
+++ b/shared/src/iosMain/kotlin/io/ak1/drawboxsample/save/ImageSaver.ios.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.asSkiaBitmap
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
@@ -18,13 +19,23 @@ import platform.Foundation.NSURL
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
 import platform.Foundation.dataWithContentsOfURL
+import platform.Foundation.NSError
+import platform.Foundation.NSItemProvider
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerFilter
+import platform.PhotosUI.PHPickerResult
+import platform.PhotosUI.PHPickerViewController
+import platform.PhotosUI.PHPickerViewControllerDelegateProtocol
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDocumentPickerDelegateProtocol
 import platform.UIKit.UIDocumentPickerViewController
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageWriteToSavedPhotosAlbum
+import platform.UniformTypeIdentifiers.UTTypeImage
 import platform.UniformTypeIdentifiers.UTTypeJSON
 import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 import kotlin.time.Clock
 
 @Composable
@@ -32,6 +43,7 @@ actual fun rememberImageSaver(): ImageSaver = remember { IosImageSaver() }
 
 private class IosImageSaver : ImageSaver {
     private var activeDelegate: JsonPickerDelegate? = null
+    private var activeImageDelegate: ImagePickerDelegate? = null
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override fun savePng(bitmap: ImageBitmap) {
@@ -103,11 +115,75 @@ private class IosImageSaver : ImageSaver {
         rootController.presentViewController(picker, true, null)
     }
 
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override fun loadImage(onLoaded: (ByteArray, Size) -> Unit) {
-        // iOS image picker requires UIImagePickerController + Photos auth or
-        // PHPickerViewController — out of scope for OSS v1. Logged as a hint
-        // for embedders; desktop & Android cover the demo.
-        NSLog("loadImage(): not implemented on iOS in OSS sample yet")
+        val rootController = UIApplication.sharedApplication.keyWindow?.rootViewController
+        if (rootController == null) {
+            NSLog("No root view controller available for PHPicker")
+            return
+        }
+        // PHPickerConfiguration with `images` filter — read-only access, no
+        // Photos library permission prompt required (this is the whole
+        // point of PHPicker vs UIImagePickerController). selectionLimit = 1
+        // matches the existing host contract (single image per call).
+        val config = PHPickerConfiguration().apply {
+            filter = PHPickerFilter.imagesFilter()
+            selectionLimit = 1
+        }
+        val picker = PHPickerViewController(configuration = config)
+        val delegate = ImagePickerDelegate(
+            onPicked = { provider ->
+                activeImageDelegate = null
+                loadImageBytesFromProvider(provider, onLoaded)
+            },
+            onCancelled = { activeImageDelegate = null },
+        )
+        activeImageDelegate = delegate
+        picker.delegate = delegate
+        rootController.presentViewController(picker, true, null)
+    }
+
+    /**
+     * Read the raw encoded bytes (PNG / JPEG / HEIC / etc.) directly from
+     * the [NSItemProvider] without any UIImage intermediate. PHPicker
+     * delivers data representations off the main thread, so we marshal the
+     * eventual `onLoaded` call back onto the main queue — the SDK's
+     * `insertImage` dispatches a reducer Intent which expects to be on the
+     * UI thread.
+     */
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private fun loadImageBytesFromProvider(
+        provider: NSItemProvider,
+        onLoaded: (ByteArray, Size) -> Unit,
+    ) {
+        val typeId = UTTypeImage.identifier
+        if (!provider.hasItemConformingToTypeIdentifier(typeId)) {
+            NSLog("PHPicker result has no image-conforming representation")
+            return
+        }
+        provider.loadDataRepresentationForTypeIdentifier(typeId) { data: NSData?, error: NSError? ->
+            if (error != null || data == null) {
+                NSLog("loadDataRepresentation failed: ${error?.localizedDescription}")
+                return@loadDataRepresentationForTypeIdentifier
+            }
+            val bytes = ByteArray(data.length.toInt())
+            bytes.usePinned { pinned ->
+                platform.posix.memcpy(pinned.addressOf(0), data.bytes, data.length)
+            }
+            // Compute intrinsic pixel size via UIImage so we match the
+            // host's "screen pixels at native scale" expectation. UIImage's
+            // `.size` is in points; multiply by `scale` to get pixels.
+            val size = UIImage.imageWithData(data)?.let { img ->
+                val s = img.size
+                Size(
+                    (s.useContents { width } * img.scale).toFloat(),
+                    (s.useContents { height } * img.scale).toFloat(),
+                )
+            } ?: Size.Zero
+            dispatch_async(dispatch_get_main_queue()) {
+                onLoaded(bytes, size)
+            }
+        }
     }
 
     @OptIn(BetaInteropApi::class)
@@ -139,5 +215,25 @@ private class JsonPickerDelegate(
 
     override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
         onCancelled()
+    }
+}
+
+private class ImagePickerDelegate(
+    private val onPicked: (NSItemProvider) -> Unit,
+    private val onCancelled: () -> Unit,
+) : NSObject(), PHPickerViewControllerDelegateProtocol {
+    override fun picker(
+        picker: PHPickerViewController,
+        didFinishPicking: List<*>,
+    ) {
+        // Dismiss before invoking the host callback so the picker chrome
+        // doesn't cover the canvas while the image lands.
+        picker.dismissViewControllerAnimated(true, null)
+        val first = didFinishPicking.firstOrNull() as? PHPickerResult
+        if (first == null) {
+            onCancelled()
+            return
+        }
+        onPicked(first.itemProvider)
     }
 }

--- a/shared/src/jsMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.js.kt
+++ b/shared/src/jsMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.js.kt
@@ -1,0 +1,54 @@
+package io.ak1.drawboxsample.save
+
+import androidx.compose.ui.geometry.Size
+import kotlinx.browser.window
+import org.jetbrains.skia.Image
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.get
+
+/**
+ * Legacy Kotlin/JS implementation. Stays in fully-dynamic territory because
+ * Kotlin/JS's standard `Promise<T>` doesn't surface chained dynamic types
+ * cleanly through the `.then()` overloads — using `js("...")` keeps the
+ * Async Clipboard call chain in JS land where the API was designed.
+ */
+actual fun pasteImageFromClipboard(
+    onLoaded: (ByteArray, Size) -> Unit,
+) {
+    val handler: (dynamic) -> Unit = { bytes ->
+        val byteArray = arrayBufferToBytes(bytes as ArrayBuffer)
+        val size = runCatching {
+            val img = Image.makeFromEncoded(byteArray)
+            Size(img.width.toFloat(), img.height.toFloat())
+        }.getOrElse { Size.Zero }
+        onLoaded(byteArray, size)
+    }
+    readClipboardImageAsArrayBuffer(handler)
+}
+
+private fun readClipboardImageAsArrayBuffer(onArrayBuffer: (dynamic) -> Unit) {
+    js("""
+        if (typeof navigator === 'undefined' || !navigator.clipboard || !navigator.clipboard.read) return;
+        navigator.clipboard.read().then(function(items) {
+            for (var i = 0; i < items.length; i++) {
+                var t = items[i].types;
+                for (var j = 0; j < t.length; j++) {
+                    if (t[j].indexOf('image/') === 0) {
+                        items[i].getType(t[j]).then(function(blob) {
+                            blob.arrayBuffer().then(function(buffer) {
+                                onArrayBuffer(buffer);
+                            });
+                        });
+                        return;
+                    }
+                }
+            }
+        }).catch(function() { });
+    """)
+}
+
+private fun arrayBufferToBytes(buffer: ArrayBuffer): ByteArray {
+    val arr = Uint8Array(buffer)
+    return ByteArray(arr.length) { i -> arr[i] }
+}

--- a/shared/src/jvmMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.jvm.kt
+++ b/shared/src/jvmMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.jvm.kt
@@ -1,0 +1,62 @@
+package io.ak1.drawboxsample.save
+
+import androidx.compose.ui.geometry.Size
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.UnsupportedFlavorException
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import javax.swing.SwingUtilities
+import kotlin.concurrent.thread
+
+actual fun pasteImageFromClipboard(
+    onLoaded: (ByteArray, Size) -> Unit,
+) {
+    // Re-encode runs off the EDT — a large clipboard bitmap can take 100+ ms
+    // through ImageIO, and the host fires this from a key handler on the UI
+    // thread. Spawn a thread, marshal the result back via SwingUtilities so
+    // the SDK's `insertImage` dispatches on the EDT (where Compose Desktop
+    // expects state writes).
+    thread(name = "drawbox-clipboard-paste", isDaemon = true) {
+        val clip = Toolkit.getDefaultToolkit().systemClipboard
+        val image: BufferedImage = try {
+            if (!clip.isDataFlavorAvailable(DataFlavor.imageFlavor)) return@thread
+            clip.getData(DataFlavor.imageFlavor) as? BufferedImage ?: return@thread
+        } catch (e: UnsupportedFlavorException) {
+            return@thread
+        } catch (e: IllegalStateException) {
+            // Another process holds the clipboard; the typical AWT response
+            // is a transient IllegalStateException. The user can retry; we
+            // don't surface this as an error.
+            return@thread
+        }
+
+        // BufferedImage.TYPE_CUSTOM (which is what some screenshot tools
+        // produce) doesn't survive ImageIO PNG writers cleanly — repaint
+        // into a TYPE_INT_ARGB intermediate so the encoder always sees a
+        // known format.
+        val normalized: BufferedImage =
+            if (image.type == BufferedImage.TYPE_INT_ARGB ||
+                image.type == BufferedImage.TYPE_INT_RGB
+            ) {
+                image
+            } else {
+                BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_ARGB).apply {
+                    val g = createGraphics()
+                    try {
+                        g.drawImage(image, 0, 0, null)
+                    } finally {
+                        g.dispose()
+                    }
+                }
+            }
+
+        val bytes = ByteArrayOutputStream(64 * 1024).use { out ->
+            if (!ImageIO.write(normalized, "png", out)) return@thread
+            out.toByteArray()
+        }
+        val size = Size(normalized.width.toFloat(), normalized.height.toFloat())
+        SwingUtilities.invokeLater { onLoaded(bytes, size) }
+    }
+}

--- a/shared/src/wasmJsMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/io/ak1/drawboxsample/save/ClipboardImage.wasmJs.kt
@@ -1,0 +1,54 @@
+package io.ak1.drawboxsample.save
+
+import androidx.compose.ui.geometry.Size
+import org.jetbrains.skia.Image
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Uint8Array
+import org.khronos.webgl.get
+
+actual fun pasteImageFromClipboard(
+    onLoaded: (ByteArray, Size) -> Unit,
+) {
+    // navigator.clipboard.read() returns Promise<ClipboardItem[]>. On
+    // browsers without the Async Clipboard API (older Safari, some
+    // mobile Chromium variants), this silently no-ops. The whole chain
+    // is kept in `js("...")` because WasmJS's typed bindings for the
+    // Async Clipboard API are incomplete — going through dynamic JS
+    // avoids fighting JsAny / Promise<JsAny> ceremony for what's
+    // ultimately a four-line callback chain.
+    readClipboardImageAsArrayBuffer { buffer ->
+        val bytes = arrayBufferToBytes(buffer)
+        val size = runCatching {
+            val img = Image.makeFromEncoded(bytes)
+            Size(img.width.toFloat(), img.height.toFloat())
+        }.getOrElse { Size.Zero }
+        onLoaded(bytes, size)
+    }
+}
+
+@JsFun(
+    """(callback) => {
+        if (typeof navigator === 'undefined' || !navigator.clipboard || !navigator.clipboard.read) return;
+        navigator.clipboard.read().then(function(items) {
+            for (var i = 0; i < items.length; i++) {
+                var t = items[i].types;
+                for (var j = 0; j < t.length; j++) {
+                    if (t[j].indexOf('image/') === 0) {
+                        items[i].getType(t[j]).then(function(blob) {
+                            blob.arrayBuffer().then(function(buffer) {
+                                callback(buffer);
+                            });
+                        });
+                        return;
+                    }
+                }
+            }
+        }).catch(function() { });
+    }""",
+)
+private external fun readClipboardImageAsArrayBuffer(callback: (ArrayBuffer) -> Unit)
+
+private fun arrayBufferToBytes(buffer: ArrayBuffer): ByteArray {
+    val arr = Uint8Array(buffer)
+    return ByteArray(arr.length) { i -> arr[i] }
+}


### PR DESCRIPTION
## Summary

Closes #79 (clipboard paste) and #80 (iOS image picker).

**Drag-and-drop (#78) is *not* in this PR** — Compose Multiplatform's \`Modifier.dragAndDropTarget\` exposes a JVM-only \`awtTransferable\` payload, the web path is undocumented, and the cross-platform shape needs its own design pass. Splitting it lets these two ship now.

## #80 — iOS PHPicker

Replaces the \`loadImage\` stub in \`shared/src/iosMain/.../ImageSaver.ios.kt\`.

- \`PHPickerConfiguration\` with \`filter = imagesFilter()\` and \`selectionLimit = 1\` — read-only access, no Photos library permission prompt.
- \`loadDataRepresentationForTypeIdentifier(UTTypeImage.identifier)\` reads encoded bytes (PNG / JPEG / HEIC / etc.) directly — no \`UIImage\` intermediate.
- Intrinsic pixel size from \`UIImage(data:).size × scale\` so HiDPI screenshots arrive at native resolution.
- \`dispatch_async(dispatch_get_main_queue())\` marshals the host callback onto the main thread since PHPicker callbacks come off-main.

## #79 — Clipboard paste

New \`expect fun pasteImageFromClipboard\` (in \`shared/commonMain/.../ClipboardImage.kt\`). HomeScreen wires it via \`Modifier.onPreviewKeyEvent\` on the \`DrawBox\` modifier chain — fires before the SDK's Space-bar pan handler so paste isn't shadowed.

| Target | Implementation |
|---|---|
| **JVM (Desktop)** | AWT \`Toolkit.systemClipboard\` + \`DataFlavor.imageFlavor\`, normalize \`TYPE_CUSTOM\` to \`TYPE_INT_ARGB\` (some screenshot tools produce custom types that \`ImageIO.write\` can't encode), re-encode to PNG, marshal back onto EDT |
| **WasmJS + JS** | \`navigator.clipboard.read()\` through inline JS shims (typed bindings are incomplete on both targets). First \`image/*\` MIME wins; \`blob.arrayBuffer()\` copied to \`ByteArray\`; intrinsic size via skia |
| **Android + iOS** | Intentional no-op — Cmd/Ctrl+V isn't a touch-platform flow; both have dedicated insertion paths (PHPicker on iOS, system picker on Android) |

Pasted image lands at viewport center (matches existing menu-driven insert UX). Hover-cursor positioning is a future improvement.

## Test plan

- [x] All six SDK + sample targets compile (jvm / android / iosArm64 / iosSimulatorArm64 / wasmJs / js).
- [x] Existing test suite passes (\`./gradlew :DrawBox:jvmTest\`).
- [ ] Manual macOS: screenshot via Cmd+Shift+4 → focus desktop app → Cmd+V → image inserts at viewport center.
- [ ] Manual Windows / Linux desktop: copy-paste via Ctrl+V from screenshot tool.
- [ ] Manual web (Chrome / Edge / Safari): copy image to clipboard → Ctrl+V → image inserts. Permission prompt expected on first call.
- [ ] Manual iOS: tap Insert image → PHPicker opens → select a photo → image inserts at native resolution. Photos library permission NOT prompted.
- [ ] Manual iOS: cancel the picker → no-op, no errors logged.

## Follow-up

- **#78** drag-and-drop still open. Will tackle when the Compose Multiplatform drag-drop API stabilizes for web, or with an expect/actual carve-out.