### PR TITLE
feat: cross-platform image inputs — clipboard paste + drag-drop

### DIFF
--- a/DrawBox/src/androidMain/kotlin/io/ak1/drawbox/input/ClipboardImage.android.kt
+++ b/DrawBox/src/androidMain/kotlin/io/ak1/drawbox/input/ClipboardImage.android.kt
@@ -1,15 +1,112 @@
 package io.ak1.drawbox.input
 
+import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import androidx.compose.ui.geometry.Size
+import java.io.ByteArrayOutputStream
 
 /**
- * Android paste is a no-op in the OSS sample. Touch-screen Android doesn't
- * have a Cmd/Ctrl+V key flow, and the existing file picker covers the
- * "insert image" path on this platform. Could be wired to `ClipboardManager`
- * + `MIMETYPE_TEXT_URILIST` in a follow-up if anyone asks.
+ * Android clipboard paste. Reads `ClipboardManager.primaryClip` for an
+ * image URI (covers Files / Gallery / Photos "Copy" flows plus browser
+ * "Copy image" on most Chromium derivatives), resolves it through the
+ * application `ContentResolver`, and delivers the bytes + intrinsic
+ * pixel size on the main thread.
+ *
+ * Targets tablets / Chromebooks / DeX where Cmd+V is a real flow, and
+ * also covers a host-supplied "paste" toolbar button on phones. Plain
+ * phones with software keyboards never hit Cmd+V, but a paste button
+ * binds to the same function so the implementation is reused.
+ *
+ * ## Why reflection for context
+ * The expect signature is a plain top-level function, not `@Composable`
+ * — it's called from `onPreviewKeyEvent`, which itself isn't
+ * `@Composable`. Reaching `LocalContext.current` from there is not
+ * possible without API-level changes that cascade through every actual
+ * + the host call site. `ActivityThread.currentApplication()` is a
+ * private-but-stable Android internal that returns the live
+ * `Application` instance; this is the canonical pattern used by
+ * LeakCanary, ProcessLifecycleOwner, Coil, and others for the same
+ * reason. If R8 strips `ActivityThread`, the call returns null and
+ * paste no-ops gracefully.
  */
 actual fun pasteImageFromClipboard(
     onLoaded: (bytes: ByteArray, intrinsicSize: Size) -> Unit,
 ) {
-    // intentionally no-op
+    val app = applicationContext() ?: run {
+        Log.w("DrawBox", "Paste: no Application context reachable; skipping.")
+        return
+    }
+    val cm = app.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        ?: return
+    val clip: ClipData = cm.primaryClip ?: return
+    if (clip.itemCount == 0) return
+
+    val resolver = app.contentResolver
+    // Decoding can hit disk through ContentResolver — run off the main
+    // thread. The host's onPreviewKeyEvent fires on the UI thread; we
+    // marshal the result back via Handler so SDK state writes happen
+    // where Compose expects them.
+    Thread({
+        val payload = (0 until clip.itemCount).firstNotNullOfOrNull { i ->
+            val item = clip.getItemAt(i)
+            val uri = item.uri ?: return@firstNotNullOfOrNull null
+            uri.toImagePayload(resolver)
+        } ?: run {
+            Log.i("DrawBox", "Paste: clipboard had no resolvable image URI.")
+            return@Thread
+        }
+        mainHandler.post { onLoaded(payload.bytes, payload.size) }
+    }, "drawbox-clipboard-paste").apply { isDaemon = true }.start()
 }
+
+private data class ImagePayload(val bytes: ByteArray, val size: Size)
+
+private fun Uri.toImagePayload(resolver: ContentResolver): ImagePayload? {
+    val raw = try {
+        resolver.openInputStream(this)?.use { it.readBytes() }
+    } catch (e: Throwable) {
+        null
+    } ?: return null
+
+    val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(raw, 0, raw.size, opts)
+    if (opts.outWidth <= 0 || opts.outHeight <= 0) return null
+
+    // If the source is already PNG, ship the bytes as-is; otherwise
+    // re-encode through the bitmap path so the SDK's decoder sees a
+    // known PNG container (matches the JVM + iOS behaviour).
+    val mime = opts.outMimeType
+    val bytes = if (mime == "image/png") {
+        raw
+    } else {
+        val bmp = BitmapFactory.decodeByteArray(raw, 0, raw.size) ?: return null
+        ByteArrayOutputStream(64 * 1024).use { out ->
+            if (!bmp.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)) {
+                return null
+            }
+            out.toByteArray()
+        }
+    }
+    return ImagePayload(bytes, Size(opts.outWidth.toFloat(), opts.outHeight.toFloat()))
+}
+
+private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
+
+/**
+ * Reach the process `Application` via `ActivityThread.currentApplication`
+ * without requiring an explicit Context parameter. See class kdoc for
+ * the rationale.
+ */
+private fun applicationContext(): Application? = runCatching {
+    Class.forName("android.app.ActivityThread")
+        .getMethod("currentApplication")
+        .invoke(null) as? Application
+}.getOrNull()

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/input/ClipboardImage.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/input/ClipboardImage.kt
@@ -25,8 +25,13 @@ import androidx.compose.ui.geometry.Size
  *   re-encoded to PNG via `ImageIO.write`.
  * - **Web (WasmJS / JS)**: `navigator.clipboard.read()` → `ClipboardItem` →
  *   `getType("image/png")` → blob → bytes.
- * - **Android / iOS**: no-op (touch-screen platforms don't have a Cmd/Ctrl+V
- *   flow; covered by drag-drop / native pickers respectively).
+ * - **Android**: `ClipboardManager.primaryClip` → image URI →
+ *   `ContentResolver` → PNG bytes (off the UI thread). Targets the
+ *   tablet / Chromebook / DeX hardware-keyboard Cmd+V flow; a host
+ *   toolbar button can bind to the same call on phones.
+ * - **iOS**: `UIPasteboard.general.image` re-encoded via
+ *   `UIImagePNGRepresentation`. Wired primarily for iPad hardware
+ *   keyboards (Cmd+V); phones go through a host toolbar button.
  */
 expect fun pasteImageFromClipboard(
     onLoaded: (bytes: ByteArray, intrinsicSize: Size) -> Unit,

--- a/DrawBox/src/iosMain/kotlin/io/ak1/drawbox/input/ClipboardImage.ios.kt
+++ b/DrawBox/src/iosMain/kotlin/io/ak1/drawbox/input/ClipboardImage.ios.kt
@@ -1,15 +1,46 @@
 package io.ak1.drawbox.input
 
 import androidx.compose.ui.geometry.Size
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
+import platform.UIKit.UIPasteboard
 
 /**
- * iOS paste is a no-op in the OSS sample. iOS has a system pasteboard
- * (`UIPasteboard.general`) that could be wired here, but the natural
- * insertion path on iOS is the PHPicker (issue #80) — that covers the
- * screenshot → annotate workflow this issue solves on Desktop / Web.
+ * iOS clipboard paste — reads `UIPasteboard.general` for an image and
+ * delivers the encoded bytes plus intrinsic pixel size. Wired primarily
+ * for **iPad with a hardware keyboard** where Cmd+V is the natural
+ * paste shortcut; iPhone users without keyboards trigger this through
+ * a host-supplied toolbar button instead.
+ *
+ * Re-encoded to PNG via `UIImagePNGRepresentation` so the SDK's decoder
+ * sees a known container regardless of what the source app put on the
+ * pasteboard (could be PNG, JPEG, TIFF, or raw pixel data).
  */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 actual fun pasteImageFromClipboard(
     onLoaded: (bytes: ByteArray, intrinsicSize: Size) -> Unit,
 ) {
-    // intentionally no-op
+    val pasteboard = UIPasteboard.generalPasteboard
+    if (!pasteboard.hasImages) return
+    val image: UIImage = pasteboard.image ?: return
+    val data: NSData = UIImagePNGRepresentation(image) ?: return
+    val bytes = ByteArray(data.length.toInt())
+    bytes.usePinned { pinned ->
+        platform.posix.memcpy(pinned.addressOf(0), data.bytes, data.length)
+    }
+    // UIImage.size is in points; multiply by `scale` so we report pixel
+    // dimensions (matches Desktop / Android / Web reporting).
+    val size = image.size.useContents {
+        Size(
+            (width * image.scale).toFloat(),
+            (height * image.scale).toFloat(),
+        )
+    }
+    onLoaded(bytes, size)
 }

--- a/DrawBox/src/iosMain/kotlin/io/ak1/drawbox/input/DragDropImage.ios.kt
+++ b/DrawBox/src/iosMain/kotlin/io/ak1/drawbox/input/DragDropImage.ios.kt
@@ -1,13 +1,50 @@
 package io.ak1.drawbox.input
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
 
 /**
- * No-op on iOS. The natural insertion path is PHPicker (issue #80, wired
- * in `ImageSaver.ios.kt`).
+ * iOS drag-and-drop probe. Compose Multiplatform 1.11 exposes
+ * `Modifier.dragAndDropTarget` on iOS targets but doesn't (yet) surface
+ * a payload accessor on the `DragAndDropEvent` analogous to JVM's
+ * `awtTransferable`. Without `DragData` or `nativeEvent`, the contents
+ * of the drop session (an array of `NSItemProvider`s in UIKit terms)
+ * aren't reachable through the Compose API.
+ *
+ * Reaching the underlying `UIDropInteraction` requires going outside
+ * Compose's modifier — adding `UIDropInteraction` to the host view's
+ * `UIView` and implementing `UIDropInteractionDelegate`. That's a real
+ * implementation but warrants a separate design pass (locating the host
+ * view, lifecycle ownership of the interaction, threading the host
+ * callback back through the SDK boundary).
+ *
+ * Tracked as part of the residual on issue #78.
  */
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @Composable
 actual fun Modifier.imageDragAndDropTarget(
     onImagesDropped: (drops: List<DroppedImage>) -> Unit,
-): Modifier = this
+): Modifier {
+    // Keep the modifier present so the host's call site stays
+    // platform-independent and we can fill in this body later without
+    // touching HomeScreen. shouldStartDragAndDrop = false makes Compose
+    // never accept a drop — equivalent to a no-op modifier, but the
+    // chain is in place for when payload extraction lands.
+    val target = remember {
+        object : DragAndDropTarget {
+            override fun onDrop(event: DragAndDropEvent): Boolean = false
+        }
+    }
+    return this.then(
+        Modifier.dragAndDropTarget(
+            shouldStartDragAndDrop = { false },
+            target = target,
+        ),
+    )
+}

--- a/DrawBox/src/wasmJsMain/kotlin/io/ak1/drawbox/input/DragDropImage.wasmJs.kt
+++ b/DrawBox/src/wasmJsMain/kotlin/io/ak1/drawbox/input/DragDropImage.wasmJs.kt
@@ -4,9 +4,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 /**
- * No-op on WasmJS for now. The Compose Multiplatform drag-drop API
- * doesn't surface a stable browser `DataTransfer` payload yet —
- * tracked as a follow-up to #78.
+ * No-op on WasmJS. Investigated against Compose Multiplatform 1.11 — the
+ * `androidx.compose.ui.draganddrop` package doesn't expose either:
+ *
+ * - `DragData` (the cross-platform abstraction over `DataTransfer`), nor
+ * - `DragAndDropEvent.nativeEvent` (the browser `DragEvent` escape hatch
+ *   we use on JVM via `awtTransferable`).
+ *
+ * Both would land on web targets in a future Compose release; until they
+ * do, the only path is raw DOM `dragover` / `drop` listeners attached
+ * outside Compose's modifier. That's a real implementation but warrants
+ * a separate design pass (positioning the listener relative to the
+ * canvas bounds, filtering drops, cleaning up on disposal).
+ *
+ * Tracked as the residual on issue #78.
  */
 @Composable
 actual fun Modifier.imageDragAndDropTarget(


### PR DESCRIPTION
## Summary
- Bundles the image-input work that was scattered across earlier branches into a single SDK-owned surface under `io.ak1.drawbox.input`.
- **Clipboard paste** is now complete across all 5 targets: JVM (AWT) and Web (Async Clipboard API) shipped earlier; this PR adds Android (`ClipboardManager` + `ContentResolver`, off-UI-thread decode) and iOS (`UIPasteboard.general.image` → PNG).
- **Drag-and-drop** is real on Desktop only (`Modifier.dragAndDropTarget` + `awtTransferable`). iOS and Web are doc-only updates explaining the Compose Multiplatform 1.11 limitation — no `DragData`, no `DragAndDropEvent.nativeEvent`, so the drop payload isn't reachable from the modifier API. iOS hangs an empty modifier chain so the call site stays platform-independent for when the API lands. Tracked as residual on #78.
- Common expects in `ClipboardImage.kt` / `DragDropImage.kt` updated to match the new per-platform behaviour.

## Per-platform status

| Target  | Clipboard paste | Drag-and-drop |
|---------|-----------------|---------------|
| JVM     | done            | done          |
| Android | done (this PR)  | n/a — touch platform, picker covers it |
| iOS     | done (this PR)  | blocked on Compose 1.11 API; modifier stubbed |
| WasmJS  | done            | blocked on Compose 1.11 API; no-op |
| JS      | done            | blocked on Compose 1.11 API; no-op |

## Notes for review
- Android reaches `Application` via `ActivityThread.currentApplication()` reflection rather than threading a `Context` parameter through every actual / host call site. Same pattern Coil / LeakCanary use; class kdoc explains the trade-off and that the SDK no-ops if R8 strips the symbol.
- iOS reports pixel size as `UIImage.size * UIImage.scale` to match what JVM/Android/Web report.
- iOS clipboard re-encodes through `UIImagePNGRepresentation` so the SDK's decoder always sees PNG, regardless of source app's pasteboard type.

## Test plan
- [ ] Desktop: copy an image from a browser / Finder → focus DrawBox → Cmd/Ctrl+V → image appears.
- [ ] Desktop: drag a PNG / JPEG from Finder onto the canvas → image appears at drop position.
- [ ] Web (WasmJS + JS): copy an image in another tab → focus the canvas → Cmd/Ctrl+V → image appears (permission prompt accepted).
- [ ] Android (tablet / Chromebook / DeX with hardware keyboard): "Copy image" from Photos / Files → focus DrawBox → Cmd+V → image appears.
- [ ] iOS / iPadOS (iPad with hardware keyboard): copy an image → Cmd+V in DrawBox → image appears.
- [ ] iOS / Web: drag-drop is intentionally a no-op; verify no regressions in the existing picker / paste paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)