### PR TITLE
release: 2.1.0-alpha01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,86 @@ The `2.0.x` line is the Kotlin Multiplatform rewrite. The `1.x` line was an Andr
 
 _Nothing yet._
 
+## [2.1.0-alpha01] — 2026-06-28
+
+First pre-release of the `2.1` line. New element types (image, text), a
+fifth published target (Kotlin/JS browser), cross-platform image input
+plumbing (OS drag-drop on Desktop; clipboard paste on Desktop, Web,
+Android, iOS; iOS PHPicker), pen-pressure sampling on supported
+hardware, and independent fill / stroke for shapes.
+
+Alpha because the new surfaces (image / text elements, `io.ak1.drawbox.input`,
+pen-pressure sample fields) may iterate based on integration feedback. The
+frozen 2.0 surfaces (`Mode`, `Intent`, `Event`, `State`, `DrawBoxController`
+core) are extended only — see _Changed_ for the one structural rename
+inside `Element.Path` and the [migration note](#migration-20x--21x) at the
+bottom.
+
+### Added
+- **Image element** (`Element.Image`, `Mode.IMAGE`). Place, transform, and
+  export bitmaps as first-class canvas elements; raw bytes are the source
+  of truth and decoding is cached per element id. (#76)
+- **Cross-platform image inputs** under `io.ak1.drawbox.input`:
+  - `pasteImageFromClipboard(...)` — JVM (AWT), Web (Async Clipboard API),
+    Android (`ClipboardManager` + `ContentResolver`), iOS
+    (`UIPasteboard.general.image` → PNG). (#91, #93)
+  - `Modifier.imageDragAndDropTarget(...)` — full implementation on JVM
+    via `awtTransferable` + `DataFlavor.javaFileListFlavor`; iOS / Web
+    targets are intentional no-ops blocked on Compose Multiplatform 1.11
+    not exposing `DragData` / `nativeEvent` on those targets (tracked as
+    residual on #78). (#92)
+  - `iOS PHPicker` wired into `ImageSaver.ios.kt` for the native
+    insertion flow on iOS / iPadOS. (#91)
+- **Text element** (`Element.Text`, `Mode.TEXT`) with inline editor,
+  `TextAlignment` enum, font-family keys via `BuiltinFontFamilyKeys`,
+  per-element wrap width / measured height, and SVG export. (#84)
+- **Pen pressure** sampling on PEN and ERASER modes. New
+  `Element.PathSample` carries `position`, `width`, and optional `tilt` /
+  `azimuth` (degrees) reported by Apple Pencil / S Pen. Mouse / capacitive
+  touch defaults to unit pressure with zero overhead. `Intent.UpdateLatestPath`
+  now takes an optional `pressure: Float = 1f`. (#75)
+- **Kotlin/JS browser target.** DrawBox now publishes a `js(browser)`
+  variant alongside Android / iOS / JVM / WASM. Sample app's `webApp` wires
+  the JS distribution end-to-end. (#86)
+- **Independent fill + stroke** on `Element.Shape`. New `strokeEnabled`
+  field (defaults `true`); `Intent.SetSelectedFillColor` and
+  `Intent.SetSelectedStrokeEnabled`; `DrawBoxController.setSelectionFillColor`
+  / `setSelectionStrokeEnabled`. ContextBar gains stroke + fill swatch
+  dropdowns with explicit "none" states. SVG export emits `stroke="none"`
+  when disabled. LINE / ARROW remain stroke-only and ignore both flags. (#82)
+- **Connector endpoint side-anchoring.** Connector endpoints snap to the
+  midpoint of the facing side of the target element instead of the nearest
+  corner, and respect rotation. (#71)
+- Roborazzi snapshot harness covering a complex multi-element scene; SVG
+  export correctness asserted against the rendered baseline. (#88)
+
+### Changed
+- **`Element.Path.points: List<Offset>` → `Element.Path.samples: List<PathSample>`.**
+  Pen-pressure work moved per-sample width / tilt / azimuth onto the path
+  itself instead of carrying a parallel widths list. A compatibility
+  extension `Element.Path.positions: List<Offset>` is provided (note: new
+  name, not a rename of `points`). **This breaks direct construction and
+  field access on `Element.Path`** — see [Migration: 2.0.x → 2.1.x](#migration-20x--21x).
+- **Async + downsampled image decode** with a mip-level cache. Image
+  rendering no longer blocks the UI thread; the decoded bitmap is sized
+  to viewport resolution and cached per `(id, zoom level)` so panning a
+  large image stays smooth. Internal; no API change. (#87)
+- iOS image saving routed through PHPicker / Files for a native feel. (#91)
+- SVG export correctness fixes surfaced by the new snapshot harness
+  (stroke caps, fill defaults, rotation transforms). (#88)
+
+### Fixed
+- Misc. SVG export edge cases caught by the new complex-scene baseline
+  (see commit `431d5d2`). (#88)
+
+### Stability
+- New surfaces in this release that may iterate before `2.1.0` stable:
+  `Element.Image`, `Element.Text`, the `io.ak1.drawbox.input` package, the
+  pen-pressure sample fields, and Kotlin/JS publishing coordinates.
+  Feedback on these surfaces is the point of the alpha — file issues
+  against [`akshay2211/DrawBox`](https://github.com/akshay2211/DrawBox/issues).
+- The 2.0 frozen surfaces are not loosened by the alpha label.
+
 ## [2.0.0] — 2026-06-24
 
 First stable release of the Kotlin Multiplatform line. Public API across
@@ -108,6 +188,98 @@ under semver; incubating surfaces opt in via explicit annotations.
 
 ---
 
+## Migration: 2.0.x → 2.1.x
+
+`2.1.0-alpha01` is additive across the frozen `2.0` surfaces with one
+exception inside `Element.Path` to make room for pen-pressure data.
+
+### `Element.Path`: `points` → `samples`
+
+Pen-pressure work moved per-sample width / tilt / azimuth onto the path
+itself. The `points: List<Offset>` field is gone; `samples: List<PathSample>`
+takes its place. Each sample carries its own width, so uniform strokes
+simply set every sample's width to the active `strokeWidth`.
+
+**Before (`2.0.x`):**
+
+```kotlin
+val path = Element.Path(
+    points = listOf(Offset(10f, 10f), Offset(20f, 20f), Offset(30f, 25f)),
+    strokeColor = Color.Black,
+    strokeWidth = 4f,
+    alpha = 1f,
+)
+
+path.points.forEach { /* ... */ }
+```
+
+**After (`2.1.x`):**
+
+```kotlin
+val path = Element.Path(
+    samples = listOf(
+        Element.PathSample(position = Offset(10f, 10f), width = 4f),
+        Element.PathSample(position = Offset(20f, 20f), width = 4f),
+        Element.PathSample(position = Offset(30f, 25f), width = 4f),
+    ),
+    strokeColor = Color.Black,
+    strokeWidth = 4f,
+    alpha = 1f,
+)
+
+// Read-only positions accessor for code that just needs the geometry:
+path.positions.forEach { /* ... */ }   // List<Offset>
+
+// Full sample stream for pressure-aware consumers:
+path.samples.forEach { /* sample.position, sample.width, sample.tilt, sample.azimuth */ }
+```
+
+Notes:
+- `positions` is an extension, not a constructor field — it's read-only.
+  Mutating the path's geometry means producing a new `samples` list.
+- `tilt` / `azimuth` are nullable; `null` means "no signal" (mouse /
+  capacitive touch). Renderers that don't care can ignore them.
+- The active stroke's `strokeWidth` on `Element.Path` is still meaningful:
+  it's the default applied to newly-appended samples while drawing.
+  Per-sample widths override it during the stroke; setters that resize the
+  whole stroke (`SetSelectedStrokeWidth`) rewrite every sample's width.
+
+### `Intent.UpdateLatestPath`: optional `pressure`
+
+`UpdateLatestPath` now takes an optional `pressure: Float = 1f`.
+Existing dispatch sites that pass only `newPoint` continue to compile
+and behave identically (unit pressure = uniform stroke). Hosts that
+want to wire pressure through pass the per-sample value.
+
+### Additive: new modes / elements / inputs
+
+These are pure additions; ignore them unless you want the feature:
+
+- `Mode.IMAGE` / `Element.Image` — image insertion + transform.
+- `Mode.TEXT` / `Element.Text` — text element with inline editor.
+- `Element.Shape.strokeEnabled: Boolean = true` — independent fill /
+  stroke. Existing serialized shapes default to `true` (matches the
+  pre-2.1 implicit "always stroked" behaviour).
+- `io.ak1.drawbox.input.pasteImageFromClipboard(...)` — opt-in clipboard
+  paste entry point. Wire it from your host's key handler / toolbar.
+- `io.ak1.drawbox.input.Modifier.imageDragAndDropTarget(...)` — opt-in
+  drag-drop modifier. Attach to the canvas composable.
+
+### Kotlin/JS coordinates
+
+If you weren't already targeting Kotlin/JS browser, nothing changes.
+If you want to consume the new JS variant, add the standard
+`js(browser)` target in your `kotlin {}` block — DrawBox publishes a
+matching klib alongside the existing Android / iOS / JVM / WASM ones.
+
+### JDK and Kotlin
+
+Unchanged from `2.0.x`: JDK 21 to build, Kotlin `2.4.x`, Compose
+Multiplatform `1.11.x`. Consuming Android apps still need
+`compileSdk 36+` and `minSdk 24+`.
+
+---
+
 ## Migration: 1.x → 2.x
 
 DrawBox `2.0.x` is a Kotlin Multiplatform rewrite. The public API has changed; the artifact coordinates (`io.ak1:drawbox`) are unchanged.
@@ -201,7 +373,8 @@ under semver. Incubating surfaces (collab plumbing, advanced eraser
 modes, etc.) are gated behind opt-in annotations and may evolve in
 minor versions.
 
-[Unreleased]: https://github.com/akshay2211/DrawBox/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/akshay2211/DrawBox/compare/v2.1.0-alpha01...HEAD
+[2.1.0-alpha01]: https://github.com/akshay2211/DrawBox/compare/v2.0.0...v2.1.0-alpha01
 [2.0.0]: https://github.com/akshay2211/DrawBox/compare/2.0.0-alpha02...v2.0.0
 [2.0.0-alpha02]: https://github.com/akshay2211/DrawBox/compare/2.0.0-alpha01...2.0.0-alpha02
 [2.0.0-alpha01]: https://github.com/akshay2211/DrawBox/releases/tag/2.0.0-alpha01

--- a/DrawBox/gradle.properties
+++ b/DrawBox/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.ak1
 POM_ARTIFACT_ID=drawbox
-VERSION_NAME=2.0.0
+VERSION_NAME=2.1.0-alpha01
 
 POM_NAME=DrawBox
 POM_DESCRIPTION=A cross-platform drawing SDK built with Kotlin Multiplatform.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ controller.events.collect { event ->  // Listen to events
 
 ## Download
 
-Latest Version: **2.0.0** (KMP Preview)
+Latest Version: **2.1.0-alpha01** (KMP Preview)
 
 [![Download](https://img.shields.io/badge/Download-blue.svg?style=flat-square)](https://search.maven.org/artifact/io.ak1/drawbox) or grab via Gradle:
 
@@ -114,7 +114,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ak1:drawbox:2.0.0")
+    implementation("io.ak1:drawbox:2.1.0-alpha01")
 }
 ```
 
@@ -125,7 +125,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.ak1:drawbox:2.0.0'
+    implementation 'io.ak1:drawbox:2.1.0-alpha01'
 }
 ```
 
@@ -134,13 +134,13 @@ dependencies {
 <dependency>
   <groupId>io.ak1</groupId>
   <artifactId>drawbox</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0-alpha01</version>
 </dependency>
 ```
 
 ### Ivy
 ```xml
-<dependency org='io.ak1' name='drawbox' rev='2.0.0'>
+<dependency org='io.ak1' name='drawbox' rev='2.1.0-alpha01'>
   <artifact name='drawbox' ext='pom' ></artifact>
 </dependency>
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,14 +23,14 @@ repositories {
 ### Kotlin DSL (Recommended)
 ```kotlin
 dependencies {
-    implementation("io.ak1:drawbox:2.0.0")
+    implementation("io.ak1:drawbox:2.1.0-alpha01")
 }
 ```
 
 ### Groovy DSL
 ```groovy
 dependencies {
-    implementation 'io.ak1:drawbox:2.0.0'
+    implementation 'io.ak1:drawbox:2.1.0-alpha01'
 }
 ```
 
@@ -39,13 +39,13 @@ dependencies {
 <dependency>
   <groupId>io.ak1</groupId>
   <artifactId>drawbox</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0-alpha01</version>
 </dependency>
 ```
 
 ### Ivy
 ```xml
-<dependency org='io.ak1' name='drawbox' rev='2.0.0'>
+<dependency org='io.ak1' name='drawbox' rev='2.1.0-alpha01'>
   <artifact name='drawbox' ext='pom' ></artifact>
 </dependency>
 ```
@@ -126,7 +126,7 @@ If you get "Unresolved reference" errors:
 If you have dependency version conflicts:
 ```kotlin
 dependencies {
-    implementation("io.ak1:drawbox:2.0.0") {
+    implementation("io.ak1:drawbox:2.1.0-alpha01") {
         exclude(group = "androidx.compose.runtime", module = "runtime")
     }
 }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -237,7 +237,7 @@ fun SimpleDrawingApp() {
 ## Troubleshooting
 
 ### "Cannot resolve symbol DrawBox"
-- Ensure DrawBox is installed: `implementation("io.ak1:drawbox:2.0.0")`
+- Ensure DrawBox is installed: `implementation("io.ak1:drawbox:2.1.0-alpha01")`
 - Run `./gradlew clean` and sync Gradle
 
 ### Canvas appears but doesn't respond to touches

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ Uses the **MVI (Model-View-Intent)** pattern with immutable state management, ma
 
 | Metric | Value |
 |--------|-------|
-| **Latest Version** | 2.0.0 |
+| **Latest Version** | 2.1.0-alpha01 |
 | **Platforms** | Android, iOS, Web, Desktop |
 | **Architecture** | MVI Pattern |
 | **State Management** | Immutable, Functional |
@@ -75,7 +75,7 @@ Add to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.ak1:drawbox:2.0.0")
+    implementation("io.ak1:drawbox:2.1.0-alpha01")
 }
 ```
 


### PR DESCRIPTION
First pre-release of the `2.1` line. Bumps `VERSION_NAME` to `2.1.0-alpha01`, rewrites the docs/READMEs to advertise the new coordinate, and fills in the `CHANGELOG.md` `[Unreleased]` block with everything landed since `v2.0.0`.

## What's in 2.1.0-alpha01

New surfaces since `v2.0.0`:
- **Image element** (`Element.Image`, `Mode.IMAGE`) — place, transform, export. (#76)
- **Text element** (`Element.Text`, `Mode.TEXT`) with inline editor, font controls, SVG export. (#84)
- **Pen pressure** on PEN / ERASER modes — `Element.PathSample` with per-sample width / tilt / azimuth; mouse/touch defaults to unit pressure with zero overhead. (#75)
- **Cross-platform image inputs** under `io.ak1.drawbox.input`:
  - `pasteImageFromClipboard(...)` on JVM, Web (WasmJS + JS), Android, iOS. (#91, #93)
  - `Modifier.imageDragAndDropTarget(...)` real on JVM; iOS / Web stubs documented as blocked on Compose Multiplatform 1.11. (#92)
  - iOS PHPicker for native insertion. (#91)
- **Kotlin/JS browser target** published alongside Android / iOS / JVM / WASM. (#86)
- **Independent fill + stroke** on `Element.Shape` (`strokeEnabled: Boolean = true`, defaults preserve back-compat). (#82)
- **Connector side-anchoring** — endpoints snap to facing side midpoint, rotation-aware. (#71)
- Roborazzi snapshot harness covering a complex multi-element scene; surfaced + fixed several SVG export edge cases. (#88)
- Async + downsampled image decode with a mip-level cache. (#87, internal perf)

## Breaking change called out in the migration guide
- `Element.Path.points: List<Offset>` → `Element.Path.samples: List<PathSample>`. Compatibility extension `Element.Path.positions` (note: renamed) returns the geometry; full sample stream exposes per-sample width / tilt / azimuth. `Intent.UpdateLatestPath` gains an optional `pressure: Float = 1f` (existing call sites unchanged).

See the new **Migration: 2.0.x → 2.1.x** section in `CHANGELOG.md` for before/after code.

## Why alpha, not 2.1.0
The new surfaces (`Element.Image`, `Element.Text`, `io.ak1.drawbox.input`, pen-pressure sample fields, JS coordinates) are likely to iterate based on integration feedback. The 2.0 frozen surfaces are extended only — see _Changed_ in the changelog for the one `Element.Path` rename.

## Release checklist
- [x] `VERSION_NAME` bumped in `DrawBox/gradle.properties`
- [x] README + docs reference the new coordinate
- [x] CHANGELOG `[2.1.0-alpha01]` block filled in
- [x] Migration: 2.0.x → 2.1.x section added
- [ ] PR merged
- [ ] `v2.1.0-alpha01` tag pushed on the merge commit
- [ ] `./gradlew publishAllPublicationsToMavenCentralRepository` run locally with signing creds

## Test plan
- [ ] CI green (Spotless, JVM tests, WASM build, iOS compile).
- [ ] Local `:DrawBox:publishToMavenLocal` succeeds and the local POM lists `2.1.0-alpha01`.
- [ ] Sample apps (`shared`, `webApp`, `androidApp`, `iosApp`) consume the bumped version without compile errors.