### PR TITLE
feat: intents SharedFlow on DrawBoxController + overlay slot on DrawBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ The `2.0.x` line is the Kotlin Multiplatform rewrite. The `1.x` line was an Andr
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **`DrawBoxController.intents: SharedFlow<Intent>`** — observable stream of
+  processed intents. Emission happens after the reducer runs and `state` has
+  been updated, so subscribers can read `state.value` at emission time and
+  see the resulting state. Unblocks layered controllers (brush), collaboration
+  transports, and analytics recorders without subclassing or state-diffing.
+  (#99)
+- **`overlay` slot on `DrawBox`** — new `overlay: @Composable BoxScope.() -> Unit`
+  parameter, composed inside the canvas `Box` above strokes and selection
+  chrome. Renders in screen space; hosts anchor to world coordinates via
+  `state.viewport`. Default is a no-op, so existing call sites are
+  unchanged. (#99)
 
 ## [2.1.0-alpha01] — 2026-06-28
 

--- a/DrawBox/build.gradle.kts
+++ b/DrawBox/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -165,6 +166,17 @@ fun DrawBox(
      * the same content (and ghost as the user types).
      */
     hiddenElementIds: Set<String> = emptySet(),
+    /**
+     * Host-owned composable rendered inside the same [Box] as the canvas,
+     * on top of all strokes and selection chrome. Composed in screen space
+     * — hosts that need world-space anchoring map through [State.viewport].
+     *
+     * The [BoxScope] receiver gives the host the usual `align` / `matchParentSize`
+     * helpers for placing chrome (brush preview, presence cursors, floating
+     * inspector chips) relative to the canvas bounds. Default is a no-op, so
+     * existing call sites are unaffected.
+     */
+    overlay: @Composable BoxScope.() -> Unit = {},
 ) {
     // Two-layer split:
     //   - finalizedLayer: cached display list of "static" elements (everything not
@@ -865,6 +877,7 @@ fun DrawBox(
                 textCache.retainOnly(liveIds)
             }
         }
+        overlay()
     }
 }
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -87,6 +87,26 @@ class DrawBoxController(
      */
     val state: StateFlow<State> = _state.asStateFlow()
 
+    private val _intents = MutableSharedFlow<Intent>(extraBufferCapacity = 64)
+    /**
+     * Reactive stream of intents that have been processed by this controller.
+     *
+     * Each intent is emitted **after** the reducer has run and [state] has been
+     * updated, so subscribers can read [state] at emission time and observe the
+     * state that the intent produced.
+     *
+     * This is the extension seam for cross-cutting concerns that need to
+     * observe the intent stream without owning it — collaboration transports,
+     * analytics, external history / macro recording, and layered controllers
+     * (e.g. brush controllers) that decorate a base [DrawBoxController].
+     *
+     * Buffered ([extraBufferCapacity]) so slow subscribers don't back-pressure
+     * the drawing loop. If a subscriber falls behind the buffer, its emissions
+     * are dropped — subscribers that require lossless delivery should collect
+     * on a dedicated dispatcher and keep their handler cheap.
+     */
+    val intents: SharedFlow<Intent> = _intents.asSharedFlow()
+
     private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
     /**
      * Side effect events like drawing saved, drawing loaded, or errors.
@@ -143,6 +163,9 @@ class DrawBoxController(
         val newState = reducer.reduce(_state.value, intent)
         _state.value = newState
         updateHistoryState()
+        // Emit AFTER state has been updated so subscribers reading state.value
+        // at the moment of emission observe the post-reduce state.
+        _intents.tryEmit(intent)
         // Handle side effects
         when (intent) {
             is Intent.SaveBitmap -> emitSaveEvent(intent.bitmap,intent.throwable)

--- a/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxControllerTest.kt
+++ b/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxControllerTest.kt
@@ -1,0 +1,59 @@
+package io.ak1.drawbox.presentation.viewmodel
+
+import androidx.compose.ui.graphics.Color
+import io.ak1.drawbox.domain.model.Intent
+import io.ak1.drawbox.domain.usecase.UseCase
+import io.ak1.drawbox.presentation.reducer.Reducer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DrawBoxControllerTest {
+
+    private fun newController() = DrawBoxController(Reducer(UseCase()))
+
+    @Test
+    fun intentsFlowEmitsEveryProcessedIntent() = runTest(StandardTestDispatcher()) {
+        val controller = newController()
+        val collected = mutableListOf<Intent>()
+        val job = launch { controller.intents.take(2).toList(collected) }
+
+        // Yield so the collector actually subscribes before we emit.
+        testScheduler.runCurrent()
+
+        controller.onIntent(Intent.SetStrokeColor(Color.Red))
+        controller.onIntent(Intent.SetStrokeWidth(7f))
+
+        job.join()
+
+        assertEquals(2, collected.size)
+        assertTrue(collected[0] is Intent.SetStrokeColor)
+        assertTrue(collected[1] is Intent.SetStrokeWidth)
+    }
+
+    @Test
+    fun intentsFlowEmitsAfterStateUpdate() = runTest(StandardTestDispatcher()) {
+        val controller = newController()
+        var stateAtEmission: Color? = null
+        val job = launch {
+            controller.intents.take(1).collect {
+                // Guarantee: at emission time, state.value already reflects the
+                // reduced intent.
+                stateAtEmission = controller.state.value.strokeColor
+            }
+        }
+        testScheduler.runCurrent()
+
+        controller.onIntent(Intent.SetStrokeColor(Color.Blue))
+        job.join()
+
+        assertEquals(Color.Blue, stateAtEmission)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previ
 compose-uiTooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
 jetbrains-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinStdlib" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlinTest" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }


### PR DESCRIPTION
Closes #99.

Two small, isolated extension seams that unblock brush cleanly and let a future collab layer drop the state-diff workaround.

## Summary

- **`DrawBoxController.intents: SharedFlow<Intent>`** — every processed intent is emitted after the reducer runs and `state` is updated, so subscribers observing an intent can read `state.value` and see the state it produced. Buffered (`extraBufferCapacity = 64`) so slow subscribers don't back-pressure the drawing loop.
- **`overlay: @Composable BoxScope.() -> Unit = {}`** on the `DrawBox` composable — composed inside the canvas `Box` above strokes and selection chrome. Screen space; hosts anchor to world coords via `state.viewport`. Default no-op keeps existing call sites unchanged.

## Not in this PR

- No `open class` on `DrawBoxController` — with `intents` exposed, hosts compose without subclassing. Left for a later, integrator-driven ask.
- No new events, intents, or modes.
- No reducer / state-shape changes.
- No behavioral change for the sample app.

## Commits

1. `feat: expose processed intents as SharedFlow on DrawBoxController`
2. `feat: add overlay slot to the DrawBox composable`
3. `test: cover intents SharedFlow; changelog for 2.1.x seams`

## Test plan

- [x] `./gradlew :DrawBox:jvmTest` — `DrawBoxControllerTest` green (intent emission order + emit-after-state-update).
- [x] `./gradlew :DrawBox:compileKotlinMetadata` — clean.
- [ ] Verify sample app still builds and behaves identically (no overlay wired up).
- [ ] Manual: subscribe to `controller.intents` from a caller and confirm each `onIntent(...)` produces one emission.