### PR TITLE
fix: ignore touch/mouse pressure and composite alpha strokes via layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ The `2.0.x` line is the Kotlin Multiplatform rewrite. The `1.x` line was an Andr
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **`DrawBoxController.intents: SharedFlow<Intent>`** — observable stream of
+  processed intents. Emission happens after the reducer runs and `state` has
+  been updated, so subscribers can read `state.value` at emission time and
+  see the resulting state. Unblocks layered controllers (brush), collaboration
+  transports, and analytics recorders without subclassing or state-diffing.
+  (#99)
+- **`overlay` slot on `DrawBox`** — new `overlay: @Composable BoxScope.() -> Unit`
+  parameter, composed inside the canvas `Box` above strokes and selection
+  chrome. Renders in screen space; hosts anchor to world coordinates via
+  `state.viewport`. Default is a no-op, so existing call sites are
+  unchanged. (#99)
 
 ## [2.1.0-alpha01] — 2026-06-28
 

--- a/DrawBox/build.gradle.kts
+++ b/DrawBox/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -165,6 +166,17 @@ fun DrawBox(
      * the same content (and ghost as the user types).
      */
     hiddenElementIds: Set<String> = emptySet(),
+    /**
+     * Host-owned composable rendered inside the same [Box] as the canvas,
+     * on top of all strokes and selection chrome. Composed in screen space
+     * — hosts that need world-space anchoring map through [State.viewport].
+     *
+     * The [BoxScope] receiver gives the host the usual `align` / `matchParentSize`
+     * helpers for placing chrome (brush preview, presence cursors, floating
+     * inspector chips) relative to the canvas bounds. Default is a no-op, so
+     * existing call sites are unaffected.
+     */
+    overlay: @Composable BoxScope.() -> Unit = {},
 ) {
     // Two-layer split:
     //   - finalizedLayer: cached display list of "static" elements (everything not
@@ -865,6 +877,7 @@ fun DrawBox(
                 textCache.retainOnly(liveIds)
             }
         }
+        overlay()
     }
 }
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/DrawBox.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.ImageShader
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.ShaderBrush
@@ -952,17 +953,23 @@ private fun DrawScope.drawGrid(vp: Viewport, bgColor: Color) {
 /**
  * Unit-clamped pressure multiplier for the current pointer sample.
  *
- * Returns `1.0` (no-signal default — uniform stroke) when:
- *   - The pointer is a mouse. Mouse pressure isn't meaningful for drawing;
- *     pretending it is would scale every stroke by a stale, half-correct value.
- *   - The reported pressure is `0.0`. Compose forwards `0.0` for events that
- *     genuinely carry no pressure (e.g. some touch screens, hover events).
+ * Returns `1.0` (no-signal default — uniform stroke) for every pointer type
+ * except [PointerType.Stylus] and [PointerType.Eraser], the only inputs
+ * with real pressure sensors. Mouse pressure isn't meaningful, and touch
+ * pressure is unreliable: Android reports noisy area-based estimates, and
+ * the W3C Pointer Events spec has browsers return the constant default
+ * `0.5` when touch hardware has no pressure sensor. Trusting that would
+ * silently halve every finger stroke on WASM/desktop (issue #98) and, when
+ * the value jitters between samples, drop the renderer into the
+ * variable-width path whose per-segment round caps bead visibly under an
+ * alpha color (issue #97).
  *
- * Otherwise the reading is clamped to `[0.2, 1.0]` so a barely-touching pen
- * still produces a visible stroke instead of a zero-width segment.
+ * For pen/stylus input the reading is clamped to `[0.2, 1.0]` so a
+ * barely-touching pen still produces a visible stroke instead of a
+ * zero-width segment. `0.0` / `NaN` from a stylus is treated as no-signal.
  */
 private fun PointerInputChange.pressureMultiplier(): Float {
-    if (type == PointerType.Mouse) return 1f
+    if (type != PointerType.Stylus && type != PointerType.Eraser) return 1f
     val p = pressure
     if (p == 0f || p.isNaN()) return 1f
     return p.coerceIn(0.2f, 1f)
@@ -1746,6 +1753,20 @@ private fun DrawScope.drawVariableWidthPath(
     fun safeOff(w: Float): Float =
         style.offLength(w.coerceAtLeast(MIN_DASH_WIDTH)).coerceAtLeast(MIN_INTERVAL_LENGTH)
 
+    // Segment-per-sample rendering with round caps beads under alpha: each
+    // cap overlaps its neighbour and the alphas accumulate at every junction
+    // (issue #97). Composite the whole stroke into an offscreen layer at
+    // full opacity and blit it once at the requested alpha so overlapping
+    // caps read as a single translucent stroke instead of a chain of dots.
+    val useLayer = alpha < 1f
+    if (useLayer) {
+        drawContext.canvas.saveLayer(
+            bounds = Rect(Offset.Zero, size),
+            paint = Paint().apply { this.alpha = alpha },
+        )
+    }
+    val segAlpha = if (useLayer) 1f else alpha
+
     var inOn = true
     var remaining = safeOn(samples[0].width)
 
@@ -1782,7 +1803,7 @@ private fun DrawScope.drawVariableWidthPath(
                     end = endPos,
                     strokeWidth = (startW + endW) * 0.5f,
                     cap = StrokeCap.Round,
-                    alpha = alpha,
+                    alpha = segAlpha,
                 )
             }
             val consumed = span * segLen
@@ -1795,6 +1816,8 @@ private fun DrawScope.drawVariableWidthPath(
             }
         }
     }
+
+    if (useLayer) drawContext.canvas.restore()
 }
 
 /**

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -87,6 +87,26 @@ class DrawBoxController(
      */
     val state: StateFlow<State> = _state.asStateFlow()
 
+    private val _intents = MutableSharedFlow<Intent>(extraBufferCapacity = 64)
+    /**
+     * Reactive stream of intents that have been processed by this controller.
+     *
+     * Each intent is emitted **after** the reducer has run and [state] has been
+     * updated, so subscribers can read [state] at emission time and observe the
+     * state that the intent produced.
+     *
+     * This is the extension seam for cross-cutting concerns that need to
+     * observe the intent stream without owning it — collaboration transports,
+     * analytics, external history / macro recording, and layered controllers
+     * (e.g. brush controllers) that decorate a base [DrawBoxController].
+     *
+     * Buffered ([extraBufferCapacity]) so slow subscribers don't back-pressure
+     * the drawing loop. If a subscriber falls behind the buffer, its emissions
+     * are dropped — subscribers that require lossless delivery should collect
+     * on a dedicated dispatcher and keep their handler cheap.
+     */
+    val intents: SharedFlow<Intent> = _intents.asSharedFlow()
+
     private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
     /**
      * Side effect events like drawing saved, drawing loaded, or errors.
@@ -143,6 +163,9 @@ class DrawBoxController(
         val newState = reducer.reduce(_state.value, intent)
         _state.value = newState
         updateHistoryState()
+        // Emit AFTER state has been updated so subscribers reading state.value
+        // at the moment of emission observe the post-reduce state.
+        _intents.tryEmit(intent)
         // Handle side effects
         when (intent) {
             is Intent.SaveBitmap -> emitSaveEvent(intent.bitmap,intent.throwable)

--- a/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxControllerTest.kt
+++ b/DrawBox/src/commonTest/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxControllerTest.kt
@@ -1,0 +1,59 @@
+package io.ak1.drawbox.presentation.viewmodel
+
+import androidx.compose.ui.graphics.Color
+import io.ak1.drawbox.domain.model.Intent
+import io.ak1.drawbox.domain.usecase.UseCase
+import io.ak1.drawbox.presentation.reducer.Reducer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DrawBoxControllerTest {
+
+    private fun newController() = DrawBoxController(Reducer(UseCase()))
+
+    @Test
+    fun intentsFlowEmitsEveryProcessedIntent() = runTest(StandardTestDispatcher()) {
+        val controller = newController()
+        val collected = mutableListOf<Intent>()
+        val job = launch { controller.intents.take(2).toList(collected) }
+
+        // Yield so the collector actually subscribes before we emit.
+        testScheduler.runCurrent()
+
+        controller.onIntent(Intent.SetStrokeColor(Color.Red))
+        controller.onIntent(Intent.SetStrokeWidth(7f))
+
+        job.join()
+
+        assertEquals(2, collected.size)
+        assertTrue(collected[0] is Intent.SetStrokeColor)
+        assertTrue(collected[1] is Intent.SetStrokeWidth)
+    }
+
+    @Test
+    fun intentsFlowEmitsAfterStateUpdate() = runTest(StandardTestDispatcher()) {
+        val controller = newController()
+        var stateAtEmission: Color? = null
+        val job = launch {
+            controller.intents.take(1).collect {
+                // Guarantee: at emission time, state.value already reflects the
+                // reduced intent.
+                stateAtEmission = controller.state.value.strokeColor
+            }
+        }
+        testScheduler.runCurrent()
+
+        controller.onIntent(Intent.SetStrokeColor(Color.Blue))
+        job.join()
+
+        assertEquals(Color.Blue, stateAtEmission)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previ
 compose-uiTooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
 jetbrains-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinStdlib" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlinTest" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }


### PR DESCRIPTION
## Summary
- Only trust pointer pressure from `Stylus` / `Eraser`. Touch and mouse fall back to `1.0`, so WASM/browser finger strokes stop being silently halved by the W3C default `0.5` reading.
- Composite `drawVariableWidthPath` through `canvas.saveLayer` when `alpha < 1`, so overlapping round caps between segments no longer stack alpha and bead the stroke.

## Fixes
- Closes #97
- Closes #98

## Test plan
- [x] `./gradlew :DrawBox:compileKotlinJvm` — clean
- [x] `./gradlew :DrawBox:compileKotlinWasmJs` — clean
- [x] `./gradlew :DrawBox:jvmTest` — green (existing pen-pressure use-case tests unchanged, they cover the domain layer which still accepts arbitrary pressure)
- [ ] Manual: draw with a finger on the WASM sample — stroke width matches the slider (was ~half before)
- [ ] Manual: draw with a translucent colour and any pressure-varying input — stroke reads as a single translucent line, no beaded circles