### PR TITLE
feat/drawbox-ui-module: MD3 Expressive UX pass + notes-app quality delta

### DIFF
--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/Intent.kt
@@ -205,6 +205,20 @@ sealed class Intent {
      */
     data class SetStrokeStyle(val style: StrokeStyle) : Intent()
 
+    /**
+     * Default fill color for new [Element.Shape]s. `null` clears the fill so
+     * new shapes render stroke-only. Has no effect on shapes already on the
+     * canvas; use [SetSelectedFillColor] to retro-edit those.
+     */
+    data class SetFillColor(val color: Color?) : Intent()
+
+    /**
+     * Default outline pass for new [Element.Shape]s. When `false`, new shapes
+     * render fill-only. Has no effect on shapes already on the canvas; use
+     * [SetSelectedStrokeEnabled] to retro-edit those.
+     */
+    data class SetStrokeEnabled(val enabled: Boolean) : Intent()
+
     /** Change the opacity/alpha for new drawings (0.0 to 1.0) */
     data class SetOpacity(val opacity: Float) : Intent()
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
@@ -55,6 +55,34 @@ sealed class Mode {
 }
 
 /**
+ * Per-tool snapshot captured by [State.toolMemory]. Restored to [State]'s
+ * top-level style fields when the user swaps back to a tool.
+ */
+data class ToolSettings(
+    val strokeColor: Color,
+    val strokeWidth: Float,
+    val strokeStyle: StrokeStyle,
+    val cornerRadius: Float,
+    val fillColor: Color?,
+    val strokeEnabled: Boolean,
+    val fontSize: Float,
+    val fontFamilyKey: String,
+    val textAlignment: TextAlignment,
+)
+
+/** Modes that carry meaningful per-tool style. Utility modes are excluded. */
+private val PersistedModes: Set<Mode> = setOf(
+    Mode.PEN, Mode.RECTANGLE, Mode.CIRCLE, Mode.TRIANGLE,
+    Mode.ARROW, Mode.LINE, Mode.TEXT,
+)
+
+/**
+ * Whether [mode] participates in [State.toolMemory] save/restore on
+ * [Intent.SetMode].
+ */
+fun Mode.persistsSettings(): Boolean = this in PersistedModes
+
+/**
  * Resize handle positions around a selected element's bounding box. Eight
  * handles in total: four corners and four edge midpoints.
  */
@@ -117,6 +145,17 @@ data class State(
      * elements instead.
      */
     val currentItemStrokeEnabled: Boolean = true,
+    /**
+     * Per-tool memory: each drawing mode (PEN, RECTANGLE, CIRCLE, TRIANGLE,
+     * ARROW, LINE, TEXT) snapshots its own color / width / style / fill /
+     * corner / text settings. On [Intent.SetMode] the outgoing mode's current
+     * top-level fields are captured here, and the incoming mode's saved
+     * settings are restored to the top-level fields. Non-drawing modes
+     * (SELECT, ERASER, PAN) don't participate — they pass through settings
+     * untouched. Users get the "each pen remembers its own color" behavior
+     * Samsung Notes / OPPO Notes use.
+     */
+    val toolMemory: Map<Mode, ToolSettings> = emptyMap(),
     /**
      * Default font size in world pixels applied to text elements inserted via
      * [Mode.TEXT]. Mutated by [Intent.SetFontSize] (the non-selection form);

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/model/State.kt
@@ -104,6 +104,20 @@ data class State(
     val currentItemCornerRadius: Float = 0f,
     val currentItemStrokeStyle: StrokeStyle = StrokeStyle.SOLID,
     /**
+     * Default fill color applied to new [Element.Shape]s (rect/circle/triangle).
+     * `null` means stroke-only — the shape renders without a fill. Mutated by
+     * [Intent.SetFillColor]; the selection form [Intent.SetSelectedFillColor]
+     * writes to selected elements instead.
+     */
+    val currentItemFillColor: Color? = null,
+    /**
+     * Whether the outline pass is drawn on new [Element.Shape]s. When `false`,
+     * new shapes render fill-only. Mutated by [Intent.SetStrokeEnabled]; the
+     * selection form [Intent.SetSelectedStrokeEnabled] writes to selected
+     * elements instead.
+     */
+    val currentItemStrokeEnabled: Boolean = true,
+    /**
      * Default font size in world pixels applied to text elements inserted via
      * [Mode.TEXT]. Mutated by [Intent.SetFontSize] (the non-selection form);
      * the selection form [Intent.SetSelectedFontSize] writes to the selected

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/domain/usecase/UseCase.kt
@@ -116,6 +116,8 @@ class UseCase {
         width: Float,
         cornerRadius: Float = 0f,
         strokeStyle: StrokeStyle = StrokeStyle.SOLID,
+        fillColor: Color? = null,
+        strokeEnabled: Boolean = true,
     ): Element.Shape {
         val now = Clock.System.now().toEpochMilliseconds()
         return Element.Shape(
@@ -125,6 +127,8 @@ class UseCase {
             strokeWidth = width,
             cornerRadius = cornerRadius,
             strokeStyle = strokeStyle,
+            fillColor = fillColor,
+            strokeEnabled = strokeEnabled,
             createdAt = now,
             modifiedAt = now,
         )

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
@@ -125,6 +125,8 @@ class Reducer(
                 state.strokeWidth,
                 state.currentItemCornerRadius,
                 state.currentItemStrokeStyle,
+                state.currentItemFillColor,
+                state.currentItemStrokeEnabled,
             )
             state.snapshot().copy(
                 elements = useCase.addElement(newShape, state.elements),
@@ -137,6 +139,8 @@ class Reducer(
         is Intent.SetStrokeWidth -> state.copy(strokeWidth = intent.width)
         is Intent.SetCornerRadius -> state.copy(currentItemCornerRadius = intent.radius)
         is Intent.SetStrokeStyle -> state.copy(currentItemStrokeStyle = intent.style)
+        is Intent.SetFillColor -> state.copy(currentItemFillColor = intent.color)
+        is Intent.SetStrokeEnabled -> state.copy(currentItemStrokeEnabled = intent.enabled)
         is Intent.SetFontSize -> state.copy(currentItemFontSize = intent.size)
         is Intent.SetFontFamily -> state.copy(currentItemFontFamilyKey = intent.fontFamilyKey)
         is Intent.SetTextAlignment -> state.copy(currentItemTextAlignment = intent.alignment)

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/reducer/Reducer.kt
@@ -5,7 +5,9 @@ import io.ak1.drawbox.domain.model.HISTORY_CAP
 import io.ak1.drawbox.domain.model.Intent
 import io.ak1.drawbox.domain.model.Mode
 import io.ak1.drawbox.domain.model.State
+import io.ak1.drawbox.domain.model.ToolSettings
 import io.ak1.drawbox.domain.model.Viewport
+import io.ak1.drawbox.domain.model.persistsSettings
 import io.ak1.drawbox.domain.usecase.UseCase
 
 /**
@@ -148,12 +150,42 @@ class Reducer(
         is Intent.SetBgColor -> state.copy(bgColor = intent.bgColor)
         is Intent.SetBackgroundPattern -> state.copy(bgPattern = intent.pattern)
         is Intent.SetMode -> {
-            // Selection is meaningful only in SELECT mode. Switching away clears it.
+            // Per-tool memory: capture the outgoing mode's style snapshot if
+            // it's a persisted mode, then restore the incoming mode's saved
+            // snapshot (if any). Utility modes (SELECT, ERASER, PAN) pass
+            // through settings unchanged in both directions.
+            val outgoingMode = state.mode
+            val snapshot = ToolSettings(
+                strokeColor = state.strokeColor,
+                strokeWidth = state.strokeWidth,
+                strokeStyle = state.currentItemStrokeStyle,
+                cornerRadius = state.currentItemCornerRadius,
+                fillColor = state.currentItemFillColor,
+                strokeEnabled = state.currentItemStrokeEnabled,
+                fontSize = state.currentItemFontSize,
+                fontFamilyKey = state.currentItemFontFamilyKey,
+                textAlignment = state.currentItemTextAlignment,
+            )
+            val nextMemory = if (outgoingMode.persistsSettings())
+                state.toolMemory + (outgoingMode to snapshot)
+            else state.toolMemory
+            val restored = if (intent.mode.persistsSettings())
+                nextMemory[intent.mode] else null
             val nextSelected = if (intent.mode == Mode.SELECT) state.selectedIds else emptySet()
             state.copy(
                 mode = intent.mode,
                 selectedIds = nextSelected,
                 marqueeRect = null,
+                toolMemory = nextMemory,
+                strokeColor = restored?.strokeColor ?: state.strokeColor,
+                strokeWidth = restored?.strokeWidth ?: state.strokeWidth,
+                currentItemStrokeStyle = restored?.strokeStyle ?: state.currentItemStrokeStyle,
+                currentItemCornerRadius = restored?.cornerRadius ?: state.currentItemCornerRadius,
+                currentItemFillColor = restored?.fillColor ?: state.currentItemFillColor,
+                currentItemStrokeEnabled = restored?.strokeEnabled ?: state.currentItemStrokeEnabled,
+                currentItemFontSize = restored?.fontSize ?: state.currentItemFontSize,
+                currentItemFontFamilyKey = restored?.fontFamilyKey ?: state.currentItemFontFamilyKey,
+                currentItemTextAlignment = restored?.textAlignment ?: state.currentItemTextAlignment,
             )
         }
 

--- a/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
+++ b/DrawBox/src/commonMain/kotlin/io/ak1/drawbox/presentation/viewmodel/DrawBoxController.kt
@@ -214,6 +214,12 @@ class DrawBoxController(
     fun setSelectionStrokeStyle(style: io.ak1.drawbox.domain.model.StrokeStyle) =
         onIntent(Intent.SetSelectedStrokeStyle(style))
 
+    /** Default fill color applied to new shapes. `null` = stroke-only. */
+    fun setFillColor(color: Color?) = onIntent(Intent.SetFillColor(color))
+
+    /** Whether new shapes render an outline pass. `false` = fill-only. */
+    fun setStrokeEnabled(enabled: Boolean) = onIntent(Intent.SetStrokeEnabled(enabled))
+
     /** Change the opacity for new drawings (0.0 to 1.0) */
     fun setOpacity(opacity: Float) = onIntent(Intent.SetOpacity(opacity))
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -53,6 +53,16 @@ tasks.register<Copy>("copyComposeResources") {
     into("src/main/assets/composeResources/drawboxsample.shared.generated.resources")
 }
 
+// drawbox-ui's Compose Resources package is "io.ak1.drawbox.ui.resources" (see
+// its build.gradle.kts). The KMP-Android library plugin doesn't auto-bundle its
+// compose resources into the consuming Android app's assets, so mirror them by
+// hand — same workaround as the shared task above.
+tasks.register<Copy>("copyDrawBoxUiComposeResources") {
+    delete("src/main/assets/composeResources/io.ak1.drawbox.ui.resources")
+    from("../drawbox-ui/src/commonMain/composeResources")
+    into("src/main/assets/composeResources/io.ak1.drawbox.ui.resources")
+}
+
 tasks.named("preBuild") {
-    dependsOn("copyComposeResources")
+    dependsOn("copyComposeResources", "copyDrawBoxUiComposeResources")
 }

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/arrow.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/arrow.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,12l14,0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M15,16l4,-4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M15,8l4,4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/border_corner_pill.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/border_corner_pill.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,20v-5c0,-6.075 4.925,-11 11,-11h5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/border_corner_rounded.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/border_corner_rounded.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,20v-10a6,6 0,0 1,6 -6h10"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/border_corner_square.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/border_corner_square.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,20v-15a1,1 0,0 1,1 -1h15"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/circle.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/circle.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,12a9,9 0,1 0,18 0a9,9 0,1 0,-18 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/dots_vertical.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/dots_vertical.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M11,12a1,1 0,1 0,2 0a1,1 0,1 0,-2 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11,19a1,1 0,1 0,2 0a1,1 0,1 0,-2 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11,5a1,1 0,1 0,2 0a1,1 0,1 0,-2 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/eraser.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/eraser.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16.95,3.46l3.59,3.59a2,2 0,0 1,0 2.83l-9.9,9.9h-6.43l-2.83,-2.83a2,2 0,0 1,0 -2.83l12.74,-12.74a2,2 0,0 1,2.83 0z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M7.5,7.5l9,9"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/export.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/export.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14,3v4a1,1 0,0 0,1 1h4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11.5,21h-4.5a2,2 0,0 1,-2 -2v-14a2,2 0,0 1,2 -2h7l5,5v5m-5,6h7m-3,-3l3,3l-3,3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/file_import.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/file_import.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14,3v4a1,1 0,0 0,1 1h4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,13v-8a2,2 0,0 1,2 -2h7l5,5v11a2,2 0,0 1,-2 2h-5.5m-9.5,-2h7m-3,-3l3,3l-3,3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/file_type_svg.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/file_type_svg.xml
@@ -1,0 +1,56 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14,3v4a1,1 0,0 0,1 1h4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,12v-7a2,2 0,0 1,2 -2h7l5,5v4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M4,20.25c0,0.414 0.336,0.75 0.75,0.75h1.25a1,1 0,0 0,1 -1v-1a1,1 0,0 0,-1 -1h-1a1,1 0,0 1,-1 -1v-1a1,1 0,0 1,1 -1h1.25a0.75,0.75 0,0 1,0.75 0.75"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M10,15l2,6l2,-6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20,15h-1a2,2 0,0 0,-2 2v2a2,2 0,0 0,2 2h1v-3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/hand_stop.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/hand_stop.xml
@@ -1,0 +1,49 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M8,13v-7.5a1.5,1.5 0,0 1,3 0v6.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11,5.5v-2a1.5,1.5 0,1 1,3 0v8.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M14,5.5a1.5,1.5 0,0 1,3 0v6.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17,7.5a1.5,1.5 0,0 1,3 0v8.5a6,6 0,0 1,-6 6h-2h0.208a6,6 0,0 1,-5.012 -2.7a69.74,69.74 0,0 1,-0.196 -0.3c-0.312,-0.479 -1.407,-2.388 -3.286,-5.728a1.5,1.5 0,0 1,0.536 -2.022a1.867,1.867 0,0 1,2.28 0.28l1.47,1.47"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/letter_t.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/letter_t.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6,4l12,0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,4l0,16"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/line.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/line.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,19l16,-14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/palette.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/palette.xml
@@ -1,0 +1,49 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,21a9,9 0,0 1,0 -18c4.97,0 9,3.582 9,8c0,1.06 -0.474,2.078 -1.318,2.828c-0.844,0.75 -1.989,1.172 -3.182,1.172h-2.5a2,2 0,0 0,-1 3.75a1.3,1.3 0,0 1,-1 2.25"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M7.5,10.5a1,1 0,1 0,2 0a1,1 0,1 0,-2 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11.5,7.5a1,1 0,1 0,2 0a1,1 0,1 0,-2 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M15.5,10.5a1,1 0,1 0,2 0a1,1 0,1 0,-2 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/png.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/png.xml
@@ -1,0 +1,56 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14,3v4a1,1 0,0 0,1 1h4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,12v-7a2,2 0,0 1,2 -2h7l5,5v4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20,15h-1a2,2 0,0 0,-2 2v2a2,2 0,0 0,2 2h1v-3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,18h1.5a1.5,1.5 0,0 0,0 -3h-1.5v6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11,21v-6l3,6v-6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/pointer.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/pointer.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14.185,13.14l5.644,-2.202c1.625,-0.634 1.538,-2.962 -0.13,-3.473l-14.319,-4.382c-1.41,-0.431 -2.73,0.888 -2.298,2.298l4.382,14.318c0.51,1.668 2.84,1.755 3.473,0.13l2.202,-5.644a1.84,1.84 0,0 1,1.045 -1.045"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#0000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/redo.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/redo.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15,14l4,-4l-4,-4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M19,10h-11a4,4 0,1 0,0 8h1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/refresh.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/refresh.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20,11a8.1,8.1 0,0 0,-15.5 -2m-0.5,-4v4h4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M4,13a8.1,8.1 0,0 0,15.5 2m0.5,4v-4h-4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/ruler.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/ruler.xml
@@ -1,0 +1,63 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19.875,8c0.621,0 1.125,0.512 1.125,1.143v5.714c0,0.631 -0.504,1.143 -1.125,1.143h-15.875a1,1 0,0 1,-1 -1v-5.857c0,-0.631 0.504,-1.143 1.125,-1.143h15.75"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M9,8v2"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6,8v3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,8v3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M18,8v3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M15,8v2"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/sketching.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/sketching.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,15c2,-4.97 7.356,-11 9,-11c4.25,0 -5.5,11.958 -3,13s5.65,-6.678 7.4,-5.902c1.75,0.777 -1.05,7.589 -0.3,8.63s3.15,-0.897 3.9,-2.728"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/square.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/square.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3,5a2,2 0,0 1,2 -2h14a2,2 0,0 1,2 2v14a2,2 0,0 1,-2 2h-14a2,2 0,0 1,-2 -2v-14"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/trash.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/trash.xml
@@ -1,0 +1,56 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,7l16,0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M10,11l0,6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M14,11l0,6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,7l1,12a2,2 0,0 0,2 2h8a2,2 0,0 0,2 -2l1,-12"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M9,7v-3a1,1 0,0 1,1 -1h4a1,1 0,0 1,1 1v3"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/triangle.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/triangle.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M10.363,3.591l-8.106,13.534a1.914,1.914 0,0 0,1.636 2.871h16.214a1.914,1.914 0,0 0,1.636 -2.87l-8.106,-13.536a1.914,1.914 0,0 0,-3.274 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/undo.xml
+++ b/androidApp/src/main/assets/composeResources/io.ak1.drawbox.ui.resources/drawable/undo.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M9,14l-4,-4l4,-4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,10h11a4,4 0,1 1,0 8h-1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1"
+      android:fillColor="#00000000"
+      android:strokeColor="#FF000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBar.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBar.kt
@@ -49,7 +49,7 @@ fun ContextBar(
     onIntent: ContextBarDispatch,
     slots: ContextBarSlots,
     modifier: Modifier = Modifier,
-    expanded: Boolean = true,
+    expanded: Boolean = false,
     colorPicker: ColorPickerSlot = { initial, onDismiss, onSelected ->
         RangVikalpColorPicker(initial, onDismiss, onSelected)
     },

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBar.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBar.kt
@@ -87,14 +87,31 @@ fun ContextBar(
 
     val items: List<FloatingMenuItem> = buildList {
         if (slots.showStroke) {
-            addAll(
-                strokeColorContextItem(
-                    state = state,
-                    dispatch = onIntent,
-                    onPickColor = { showStrokeDialog = true },
-                    toggleable = slots.strokeToggleable,
-                ),
-            )
+            // When fill is also on, collapse stroke + strokeEnabled + fill into
+            // ONE consolidated "colors" chip whose submenu groups the sections.
+            // Cuts a shape selection's bar from 5 config chips to 4 and matches
+            // the Samsung Notes / Figma pattern.
+            if (slots.showFill) {
+                addAll(
+                    colorsContextItem(
+                        state = state,
+                        dispatch = onIntent,
+                        onPickStrokeColor = { showStrokeDialog = true },
+                        onPickFillColor = { showFillDialog = true },
+                        strokeToggleable = slots.strokeToggleable,
+                        showFill = true,
+                    ),
+                )
+            } else {
+                addAll(
+                    strokeColorContextItem(
+                        state = state,
+                        dispatch = onIntent,
+                        onPickColor = { showStrokeDialog = true },
+                        toggleable = slots.strokeToggleable,
+                    ),
+                )
+            }
         }
         if (slots.showText) {
             addAll(
@@ -106,15 +123,8 @@ fun ContextBar(
                 ),
             )
         }
-        if (slots.showFill) {
-            addAll(
-                fillContextItems(
-                    state = state,
-                    dispatch = onIntent,
-                    onPickFillColor = { showFillDialog = true },
-                ),
-            )
-        }
+        // showFill alone (without showStroke) is now a no-op — its behavior is
+        // owned by the combined colors chip above.
         if (slots.showShapeStroke) {
             addAll(shapeStrokeContextItems(state = state, dispatch = onIntent))
         }

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarIcons.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarIcons.kt
@@ -90,6 +90,27 @@ internal fun FillSwatchIcon(color: Color?) {
     }
 }
 
+/**
+ * Compound "stroke ring + fill center" swatch — the parent chip for the
+ * combined colors slot. Stroke reads as a 1.5dp ring on the outside; fill
+ * reads as the inner disc. If stroke is disabled the ring becomes the
+ * outline token; if fill is null the inner is transparent.
+ */
+@Composable
+internal fun ColorsSwatchIcon(strokeColor: Color, strokeEnabled: Boolean, fillColor: Color?) {
+    val outline = MaterialTheme.colorScheme.outline
+    val ringColor = if (strokeEnabled) strokeColor else outline
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .clip(CircleShape)
+            .background(fillColor ?: Color.Transparent)
+            .border(1.5.dp, ringColor, CircleShape),
+    ) {
+        if (!strokeEnabled && fillColor == null) DiagonalSlash(outline)
+    }
+}
+
 @Composable
 internal fun FillNoneIcon(color: Color) {
     val shape = RoundedCornerShape(4.dp)

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarItems.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarItems.kt
@@ -122,11 +122,16 @@ fun colorsContextItem(
                 },
             ),
         )
-        if (strokeToggleable) {
+        // "No stroke" / "No fill" toggles only appear when the OTHER target
+        // is currently visible — otherwise turning this one off would leave
+        // the shape invisible (invariant: at least one of stroke / fill on).
+        val strokeIsOn = state.strokeEnabled
+        val fillIsOn = state.fillColor != null
+        if (strokeToggleable && fillIsOn) {
             add(
                 FloatingMenuItem(
                     id = "colors-stroke-none",
-                    isActive = !state.strokeEnabled,
+                    isActive = !strokeIsOn,
                     icon = { isActive -> StrokeNoneIcon(color = isActive.activeIconTint()) },
                     onClick = { dispatch(ContextBarIntent.SetStrokeEnabled(false)) },
                 ),
@@ -137,19 +142,21 @@ fun colorsContextItem(
             add(
                 FloatingMenuItem(
                     id = "colors-fill",
-                    isActive = state.fillColor != null,
+                    isActive = fillIsOn,
                     icon = { _ -> FillSwatchIcon(color = state.fillColor) },
                     onClick = onPickFillColor,
                 ),
             )
-            add(
-                FloatingMenuItem(
-                    id = "colors-fill-none",
-                    isActive = state.fillColor == null,
-                    icon = { isActive -> FillNoneIcon(color = isActive.activeIconTint()) },
-                    onClick = { dispatch(ContextBarIntent.SetFillColor(null)) },
-                ),
-            )
+            if (strokeIsOn) {
+                add(
+                    FloatingMenuItem(
+                        id = "colors-fill-none",
+                        isActive = !fillIsOn,
+                        icon = { isActive -> FillNoneIcon(color = isActive.activeIconTint()) },
+                        onClick = { dispatch(ContextBarIntent.SetFillColor(null)) },
+                    ),
+                )
+            }
         }
     }
     return listOf(

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarItems.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarItems.kt
@@ -1,7 +1,6 @@
 package io.ak1.drawbox.ui.context
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.FlipToBack
@@ -361,7 +360,11 @@ fun textContextItems(
 }
 
 /**
- * Selection actions: bring to front, send to back, delete, clear.
+ * Selection actions: bring to front, send to back, delete.
+ *
+ * Deselection is not surfaced as a chip — tapping empty canvas, Esc, or
+ * switching tools all deselect for free. A dedicated "clear" affordance is
+ * the least-used chip in the pill and the cheapest to drop.
  */
 @Composable
 fun selectionContextItems(dispatch: ContextBarDispatch): List<FloatingMenuItem> {
@@ -395,17 +398,6 @@ fun selectionContextItems(dispatch: ContextBarDispatch): List<FloatingMenuItem> 
                 Icon(Icons.Filled.Delete, contentDescription = "Delete selection", tint = errorTint)
             },
             onClick = { dispatch(ContextBarIntent.Delete) },
-        ),
-        FloatingMenuItem(
-            id = "clear",
-            icon = { isActive ->
-                Icon(
-                    Icons.Filled.Close,
-                    contentDescription = "Clear selection",
-                    tint = isActive.activeIconTint(),
-                )
-            },
-            onClick = { dispatch(ContextBarIntent.ClearSelection) },
         ),
     )
 }

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarItems.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/context/ContextBarItems.kt
@@ -17,6 +17,7 @@ import io.ak1.drawbox.ui.model.ContextBarIntent
 import io.ak1.drawbox.ui.model.ContextBarState
 import io.ak1.drawbox.ui.toolbar.FloatingMenuItem
 import io.ak1.drawbox.ui.toolbar.activeIconTint
+import io.ak1.drawbox.ui.toolbar.separator
 import kotlin.math.abs
 
 /** Stroke-width presets surfaced by the shape stroke-width sub-menu. */
@@ -81,6 +82,90 @@ fun strokeColorContextItem(
         )
     }
     return listOf(root)
+}
+
+/**
+ * Combined stroke + fill "colors" slot. One parent chip whose vertical submenu
+ * groups stroke and fill sections:
+ *
+ *   [stroke swatch → picker]
+ *   [no-stroke toggle]        (only if [strokeToggleable])
+ *   ─────
+ *   [fill swatch → picker]    (only if [showFill])
+ *   [no-fill toggle]          (only if [showFill])
+ *
+ * Emit this instead of separate [strokeColorContextItem] + [fillContextItems]
+ * when the host wants one consolidated colors chip — same UX Samsung Notes and
+ * Figma use. Falls back to a simple stroke-only chip when [showFill] is false
+ * and [strokeToggleable] is false.
+ */
+fun colorsContextItem(
+    state: ContextBarState,
+    dispatch: ContextBarDispatch,
+    onPickStrokeColor: () -> Unit,
+    onPickFillColor: () -> Unit,
+    strokeToggleable: Boolean = false,
+    showFill: Boolean = false,
+): List<FloatingMenuItem> {
+    // Degenerate case — no toggle, no fill — just the plain stroke picker.
+    if (!strokeToggleable && !showFill) {
+        return strokeColorContextItem(state, dispatch, onPickStrokeColor, toggleable = false)
+    }
+    val children = buildList {
+        add(
+            FloatingMenuItem(
+                id = "colors-stroke",
+                isActive = state.strokeEnabled,
+                icon = { _ -> StrokeSwatchIcon(color = state.strokeColor, enabled = true) },
+                onClick = {
+                    if (!state.strokeEnabled) dispatch(ContextBarIntent.SetStrokeEnabled(true))
+                    onPickStrokeColor()
+                },
+            ),
+        )
+        if (strokeToggleable) {
+            add(
+                FloatingMenuItem(
+                    id = "colors-stroke-none",
+                    isActive = !state.strokeEnabled,
+                    icon = { isActive -> StrokeNoneIcon(color = isActive.activeIconTint()) },
+                    onClick = { dispatch(ContextBarIntent.SetStrokeEnabled(false)) },
+                ),
+            )
+        }
+        if (showFill) {
+            add(separator("colors-sep"))
+            add(
+                FloatingMenuItem(
+                    id = "colors-fill",
+                    isActive = state.fillColor != null,
+                    icon = { _ -> FillSwatchIcon(color = state.fillColor) },
+                    onClick = onPickFillColor,
+                ),
+            )
+            add(
+                FloatingMenuItem(
+                    id = "colors-fill-none",
+                    isActive = state.fillColor == null,
+                    icon = { isActive -> FillNoneIcon(color = isActive.activeIconTint()) },
+                    onClick = { dispatch(ContextBarIntent.SetFillColor(null)) },
+                ),
+            )
+        }
+    }
+    return listOf(
+        FloatingMenuItem(
+            id = "colors",
+            icon = { _ ->
+                ColorsSwatchIcon(
+                    strokeColor = state.strokeColor,
+                    strokeEnabled = state.strokeEnabled,
+                    fillColor = state.fillColor,
+                )
+            },
+            children = children,
+        ),
+    )
 }
 
 /**

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/controls/ControlsBar.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/controls/ControlsBar.kt
@@ -130,7 +130,7 @@ data class ControlsBarLabels(
 fun ControlsBar(
     items: List<FloatingMenuItem>,
     modifier: Modifier = Modifier,
-    expanded: Boolean = true,
+    expanded: Boolean = false,
     submenuPosition: SubmenuPosition = SubmenuPosition.Above,
     leading: List<FloatingMenuItem> = emptyList(),
     trailing: List<FloatingMenuItem> = emptyList(),

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/controls/ControlsBar.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/controls/ControlsBar.kt
@@ -2,6 +2,7 @@
 
 package io.ak1.drawbox.ui.controls
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -23,12 +24,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.ak1.drawbox.domain.model.Mode
 import io.ak1.drawbox.ui.icons.DrawBoxIcons
 import io.ak1.drawbox.ui.picker.ColorPickerSlot
+import io.ak1.drawbox.ui.picker.MultiTargetColorPicker
 import io.ak1.drawbox.ui.picker.RangVikalpColorPicker
 import io.ak1.drawbox.ui.toolbar.ExpandableFloatingToolbar
 import io.ak1.drawbox.ui.toolbar.FloatingMenuItem
@@ -53,6 +59,16 @@ data class ControlsBarState(
     val canRedo: Boolean = false,
     val strokeColor: Color = Color.Black,
     val recentColors: List<Color> = emptyList(),
+    /**
+     * When true, the color swatch renders as a 45°-split disc (stroke ring on
+     * the top-left, fill disc on the bottom-right) and taps open the multi-
+     * target picker. Enable only for elements/modes that support both stroke
+     * AND fill — closed shapes (rect, circle, triangle). Everything else keeps
+     * the plain single-target swatch.
+     */
+    val showFillTarget: Boolean = false,
+    val strokeEnabled: Boolean = true,
+    val fillColor: Color? = null,
 )
 
 /** Every user gesture a [ControlsBar] can emit. */
@@ -61,6 +77,8 @@ sealed interface ControlsBarIntent {
     data object Redo : ControlsBarIntent
     data class SelectMode(val mode: Mode) : ControlsBarIntent
     data class SetStrokeColor(val color: Color) : ControlsBarIntent
+    data class SetStrokeEnabled(val enabled: Boolean) : ControlsBarIntent
+    data class SetFillColor(val color: Color?) : ControlsBarIntent
 }
 
 typealias ControlsBarDispatch = (ControlsBarIntent) -> Unit
@@ -165,11 +183,25 @@ fun defaultControlsBarItems(
 ): List<FloatingMenuItem> {
     var showPicker by remember { mutableStateOf(false) }
     if (showPicker) {
-        colorPicker(
-            state.strokeColor,
-            { showPicker = false },
-            { color -> dispatch(ControlsBarIntent.SetStrokeColor(color)) },
-        )
+        // Fillable target => multi-target picker (Border / Fill tabs +
+        // off-toggle). Non-fillable => plain single-target picker as before.
+        if (state.showFillTarget) {
+            MultiTargetColorPicker(
+                strokeColor = state.strokeColor,
+                strokeEnabled = state.strokeEnabled,
+                fillColor = state.fillColor,
+                onDismiss = { showPicker = false },
+                onStrokeSelected = { dispatch(ControlsBarIntent.SetStrokeColor(it)) },
+                onStrokeEnabledChanged = { dispatch(ControlsBarIntent.SetStrokeEnabled(it)) },
+                onFillSelected = { dispatch(ControlsBarIntent.SetFillColor(it)) },
+            )
+        } else {
+            colorPicker(
+                state.strokeColor,
+                { showPicker = false },
+                { color -> dispatch(ControlsBarIntent.SetStrokeColor(color)) },
+            )
+        }
     }
 
     var lastShape by remember { mutableStateOf(shapes.firstOrNull() ?: Mode.RECTANGLE) }
@@ -231,11 +263,23 @@ private fun colorSwatchItem(
     labels: ControlsBarLabels,
     onPickColor: () -> Unit,
 ): FloatingMenuItem {
+    val swatchIcon: @Composable () -> Unit = {
+        if (state.showFillTarget) {
+            SplitColorSwatch(
+                strokeColor = state.strokeColor,
+                strokeEnabled = state.strokeEnabled,
+                fillColor = state.fillColor,
+                contentDescription = labels.color,
+            )
+        } else {
+            ColorSwatchButton(color = state.strokeColor, contentDescription = labels.color)
+        }
+    }
     val recents = state.recentColors
     if (recents.isEmpty()) {
         return FloatingMenuItem(
             id = "color",
-            icon = { _ -> ColorSwatchButton(color = state.strokeColor, contentDescription = labels.color) },
+            icon = { _ -> swatchIcon() },
             onClick = onPickColor,
         )
     }
@@ -260,7 +304,7 @@ private fun colorSwatchItem(
     }
     return FloatingMenuItem(
         id = "color",
-        icon = { _ -> ColorSwatchButton(color = state.strokeColor, contentDescription = labels.color) },
+        icon = { _ -> swatchIcon() },
         // onClick = null → tapping opens the submenu of recents + custom.
         children = listOf(paletteChild) + recentChildren,
     )
@@ -275,6 +319,84 @@ private fun ColorSwatchButton(color: Color, contentDescription: String, size: Dp
             .background(color)
             .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape),
     )
+}
+
+/**
+ * 45°-split disc showing stroke and fill together — top-left half = border
+ * color, bottom-right half = fill color. When a target is disabled (stroke
+ * off / fill null) that half renders as transparent with a diagonal slash
+ * inside the outline, mirroring the "no stroke"/"no fill" idiom in
+ * ContextBarIcons.
+ */
+@Composable
+private fun SplitColorSwatch(
+    strokeColor: Color,
+    strokeEnabled: Boolean,
+    fillColor: Color?,
+    contentDescription: String,
+    size: Dp = 20.dp,
+) {
+    val outline = MaterialTheme.colorScheme.outline
+    Canvas(modifier = Modifier.size(size)) {
+        val d = this.size.minDimension
+        val topLeft = Offset(
+            (this.size.width - d) / 2f,
+            (this.size.height - d) / 2f,
+        )
+        val arcSize = Size(d, d)
+        // Top-left half (stroke). Compose Canvas angles: 0°=east, +sweep=CW,
+        // so start=135° sweep=180° fills the region above the SW→NE diagonal.
+        if (strokeEnabled) {
+            drawArc(
+                color = strokeColor,
+                startAngle = 135f,
+                sweepAngle = 180f,
+                useCenter = true,
+                topLeft = topLeft,
+                size = arcSize,
+            )
+        }
+        // Bottom-right half (fill).
+        if (fillColor != null) {
+            drawArc(
+                color = fillColor,
+                startAngle = 315f,
+                sweepAngle = 180f,
+                useCenter = true,
+                topLeft = topLeft,
+                size = arcSize,
+            )
+        }
+        // Diagonal slashes for disabled halves. Each slash runs NW→SE
+        // (perpendicular to the SW→NE split axis) and stays inside its own
+        // half — a point (x, y) is in the top-left half when x+y < d.
+        val strokeW = 1.5.dp.toPx()
+        if (!strokeEnabled) {
+            drawLine(
+                color = outline,
+                start = topLeft + Offset(d * 0.15f, d * 0.40f),
+                end = topLeft + Offset(d * 0.40f, d * 0.15f),
+                strokeWidth = strokeW,
+                cap = StrokeCap.Round,
+            )
+        }
+        if (fillColor == null) {
+            drawLine(
+                color = outline,
+                start = topLeft + Offset(d * 0.60f, d * 0.85f),
+                end = topLeft + Offset(d * 0.85f, d * 0.60f),
+                strokeWidth = strokeW,
+                cap = StrokeCap.Round,
+            )
+        }
+        // Outline circle on top.
+        drawCircle(
+            color = outline,
+            radius = d / 2f,
+            center = topLeft + Offset(d / 2f, d / 2f),
+            style = Stroke(width = 1.dp.toPx()),
+        )
+    }
 }
 
 private fun modeItem(

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/picker/ColorPickers.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/picker/ColorPickers.kt
@@ -156,12 +156,20 @@ fun MultiTargetColorPicker(
                         onClick = { target = ColorTarget.Fill },
                     )
                     Spacer(Modifier.width(4.dp))
+                    // Off-toggle is only offered when (a) the target being
+                    // edited is currently active AND (b) the OTHER target is
+                    // active — turning off the last visible layer would leave
+                    // the shape invisible, so we simply don't show the button.
                     val offLabel = if (target == ColorTarget.Border) "No stroke" else "No fill"
-                    val offEnabled = when (target) {
+                    val currentIsOn = when (target) {
                         ColorTarget.Border -> strokeEnabled
                         ColorTarget.Fill -> fillColor != null
                     }
-                    if (offEnabled) {
+                    val otherIsOn = when (target) {
+                        ColorTarget.Border -> fillColor != null
+                        ColorTarget.Fill -> strokeEnabled
+                    }
+                    if (currentIsOn && otherIsOn) {
                         TextButton(onClick = {
                             when (target) {
                                 ColorTarget.Border -> onStrokeEnabledChanged(false)

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/picker/ColorPickers.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/picker/ColorPickers.kt
@@ -1,12 +1,34 @@
 package io.ak1.drawbox.ui.picker
 
+ import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.ak1.rangvikalp.RangVikalp
@@ -40,19 +62,187 @@ fun RangVikalpColorPicker(
     onSelected: (Color) -> Unit,
 ) {
     val state = rememberRangVikalpState(initial = initial)
-    val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
     Dialog(onDismissRequest = onDismiss) {
-        Column(
-            modifier = Modifier.size(220.dp, 390.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
-            RangVikalp(
-                state = state,
-                colors = defaultRangVikalpColors(dark = isDark),
-                onColorChange = onSelected,
-            )
+            Column(
+                modifier = Modifier.size(220.dp, 390.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                RangVikalp(
+                    state = state,
+                    colors = defaultRangVikalpColors(dark = isDark),
+                    onColorChange = onSelected,
+                )
+            }
         }
     }
 }
 
 private fun Color.luminance(): Float = 0.2126f * red + 0.7152f * green + 0.0722f * blue
+
+/**
+ * Which color slot the picker is currently editing. Toggled by the Border /
+ * Fill tabs at the top of [MultiTargetColorPicker].
+ */
+enum class ColorTarget { Border, Fill }
+
+/**
+ * Color picker for fillable shapes — one dialog that edits both stroke and
+ * fill. Tabs at the top switch the RangVikalp grid between the two targets;
+ * an off-toggle disables the active target ("no stroke" / "no fill").
+ *
+ * Mirrors the single-swatch UX used by Figma / Sketch / OPPO Notes — the user
+ * sees both current colors at a glance and never has to open two dialogs.
+ *
+ * @param onStrokeSelected invoked with a non-null color when the user picks a
+ *   border color from the grid. Also fires with the previous stroke color when
+ *   the user re-enables stroke after having toggled it off.
+ * @param onStrokeEnabledChanged invoked with `false` when the user hits the
+ *   off-toggle while on the Border tab.
+ * @param onFillSelected invoked with a non-null color when the user picks a
+ *   fill color, or with `null` when they hit the off-toggle while on the Fill
+ *   tab.
+ */
+@Composable
+fun MultiTargetColorPicker(
+    strokeColor: Color,
+    strokeEnabled: Boolean,
+    fillColor: Color?,
+    onDismiss: () -> Unit,
+    onStrokeSelected: (Color) -> Unit,
+    onStrokeEnabledChanged: (Boolean) -> Unit,
+    onFillSelected: (Color?) -> Unit,
+) {
+    var target by remember { mutableStateOf(ColorTarget.Border) }
+    val isDark = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    // Seed RangVikalp with whichever color the current tab is editing so the
+    // grid highlights the right swatch on open + tab switch.
+    val seed = when (target) {
+        ColorTarget.Border -> strokeColor
+        ColorTarget.Fill -> fillColor ?: strokeColor
+    }
+    val state = rememberRangVikalpState(initial = seed)
+    LaunchedEffect(target) { state.setFromColor(seed) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    TargetTab(
+                        label = "Border",
+                        color = strokeColor,
+                        enabled = strokeEnabled,
+                        selected = target == ColorTarget.Border,
+                        onClick = { target = ColorTarget.Border },
+                    )
+                    TargetTab(
+                        label = "Fill",
+                        color = fillColor ?: Color.Transparent,
+                        enabled = fillColor != null,
+                        selected = target == ColorTarget.Fill,
+                        onClick = { target = ColorTarget.Fill },
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    val offLabel = if (target == ColorTarget.Border) "No stroke" else "No fill"
+                    val offEnabled = when (target) {
+                        ColorTarget.Border -> strokeEnabled
+                        ColorTarget.Fill -> fillColor != null
+                    }
+                    if (offEnabled) {
+                        TextButton(onClick = {
+                            when (target) {
+                                ColorTarget.Border -> onStrokeEnabledChanged(false)
+                                ColorTarget.Fill -> onFillSelected(null)
+                            }
+                        }) { Text(offLabel) }
+                    }
+                }
+                Column(modifier = Modifier.size(220.dp, 380.dp)) {
+                    RangVikalp(
+                        state = state,
+                        colors = defaultRangVikalpColors(dark = isDark),
+                        onColorChange = { color ->
+                            when (target) {
+                                ColorTarget.Border -> {
+                                    if (!strokeEnabled) onStrokeEnabledChanged(true)
+                                    onStrokeSelected(color)
+                                }
+                                ColorTarget.Fill -> onFillSelected(color)
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Border / Fill target chip inside [MultiTargetColorPicker]. Shows a swatch of
+ * the current color; a slash overlay when the target is disabled (no stroke /
+ * no fill); a primary-tinted ring when selected.
+ */
+@Composable
+private fun TargetTab(
+    label: String,
+    color: Color,
+    enabled: Boolean,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val outline = MaterialTheme.colorScheme.outline
+    val primary = MaterialTheme.colorScheme.primary
+    Row(
+        modifier = Modifier
+            .clip(CircleShape)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(18.dp)
+                .clip(CircleShape)
+                .background(if (enabled) color else Color.Transparent)
+                .border(
+                    width = if (selected) 2.dp else 1.dp,
+                    color = if (selected) primary else outline,
+                    shape = CircleShape,
+                ),
+        ) {
+            if (!enabled) androidx.compose.foundation.Canvas(Modifier.size(18.dp)) {
+                drawLine(
+                    color = outline,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, 0f),
+                    strokeWidth = 1.5f,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = if (selected) primary else MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+// Suppress unused-import warning for Stroke — reserved for a follow-up that
+// gives the split-disc swatch a proper outer stroke ring.
+@Suppress("unused")
+private val strokeReserved: (Stroke) -> Unit = { _ -> }

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/toolbar/ExpandableFloatingToolbar.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/toolbar/ExpandableFloatingToolbar.kt
@@ -101,7 +101,7 @@ enum class SubmenuPosition { Above, Below }
 fun ExpandableFloatingToolbar(
     items: List<FloatingMenuItem>,
     modifier: Modifier = Modifier,
-    expanded: Boolean = true,
+    expanded: Boolean = false,
     submenuPosition: SubmenuPosition = SubmenuPosition.Above,
     horizontalColors: FloatingToolbarColors = FloatingToolbarDefaults.standardFloatingToolbarColors(),
     verticalColors: FloatingToolbarColors = FloatingToolbarDefaults.standardFloatingToolbarColors(),

--- a/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/toolbar/ExpandableFloatingToolbar.kt
+++ b/drawbox-ui/src/commonMain/kotlin/io/ak1/drawbox/ui/toolbar/ExpandableFloatingToolbar.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingToolbarColors
 import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -171,6 +172,16 @@ fun ExpandableFloatingToolbar(
                     .requiredWidth(40.dp),
                 content = {
                     current.children.forEach { child ->
+                        if (child.isSeparator) {
+                            HorizontalDivider(
+                                modifier = Modifier
+                                    .align(Alignment.CenterHorizontally)
+                                    .requiredWidth(20.dp)
+                                    .padding(vertical = 4.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                            )
+                            return@forEach
+                        }
                         IconButton(
                             onClick = {
                                 child.onClick?.invoke()

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/App.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/App.kt
@@ -19,7 +19,7 @@ fun App() {
     var themeMode by rememberSaveable { mutableStateOf(ThemeMode.SYSTEM) }
     DrawBoxTheme(darkTheme = themeMode.resolveIsDark()) {
         Surface(
-            color = MaterialTheme.colorScheme.background,
+            color = MaterialTheme.colorScheme.surface,
             modifier = Modifier.fillMaxSize(),
         ) {
             HomeScreen(

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -2,6 +2,8 @@
 
 package io.ak1.drawboxsample.ui
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -18,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
@@ -238,6 +241,16 @@ fun HomeScreen(
         viewModel.setBackgroundPattern(patternPainter, patternTint)
     }
 
+    // Fade all floating chrome down to 0.35 alpha while the user's actively
+    // touching the canvas — matches the Samsung / OPPO Notes idle-canvas
+    // pattern. Peek at pointer events on the Initial pass so DrawBox still
+    // sees them un-consumed.
+    var isGesturing by remember { mutableStateOf(false) }
+    val chromeAlpha by animateFloatAsState(
+        targetValue = if (isGesturing) 0.35f else 1f,
+        animationSpec = tween(durationMillis = 120),
+        label = "chromeAlpha",
+    )
 
     Scaffold { _ ->
 
@@ -245,6 +258,14 @@ fun HomeScreen(
             state = state,
             onIntent = viewModel::onIntent,
             modifier = Modifier.fillMaxSize().clipToBounds()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            isGesturing = event.changes.any { it.pressed }
+                        }
+                    }
+                }
                 // OS drag-drop: dragging image files from Finder /
                 // Explorer onto the canvas inserts them at the drop
                 // point. Each file in a multi-file drop gets a small
@@ -289,6 +310,56 @@ fun HomeScreen(
         )
         BoxWithConstraints(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
             val isNarrow = maxWidth < 600.dp
+            val density = androidx.compose.ui.platform.LocalDensity.current
+            val viewportW = with(density) { maxWidth.toPx() }
+            val viewportH = with(density) { maxHeight.toPx() }
+
+            // Selection-anchor math for the selection ContextBar. Computes the
+            // union of selected element bounds in world space, converts to
+            // screen space, and returns an (x, y) top-left anchor to hang the
+            // pill from. Falls back to null (→ fixed top-right) when the
+            // selection is entirely off-screen or spans the viewport.
+            val selectionAnchor: androidx.compose.ui.unit.DpOffset? = remember(
+                state.selectedIds, state.elements, state.viewport, viewportW, viewportH,
+            ) {
+                if (!hasSelection) return@remember null
+                val worldRects = state.elements
+                    .filter { it.id in state.selectedIds }
+                    .map { it.bounds() }
+                if (worldRects.isEmpty()) return@remember null
+                val worldLeft = worldRects.minOf { it.left }
+                val worldTop = worldRects.minOf { it.top }
+                val worldRight = worldRects.maxOf { it.right }
+                val worldBottom = worldRects.maxOf { it.bottom }
+                val topLeftS = state.viewport.worldToScreen(Offset(worldLeft, worldTop))
+                val bottomRightS = state.viewport.worldToScreen(Offset(worldRight, worldBottom))
+                val onScreen = topLeftS.x < viewportW && bottomRightS.x > 0f &&
+                    topLeftS.y < viewportH && bottomRightS.y > 0f
+                val spansViewport = (bottomRightS.x - topLeftS.x) > viewportW * 0.9f ||
+                    (bottomRightS.y - topLeftS.y) > viewportH * 0.9f
+                if (!onScreen || spansViewport) return@remember null
+                // Anchor above the selection with a 12dp gap and estimate the
+                // pill's own height at 48dp. Fall back to below when the top
+                // slot would collide with the app-bar area (< 72dp from top).
+                val barHeightPx = with(density) { 48.dp.toPx() }
+                val gapPx = with(density) { 12.dp.toPx() }
+                val topAbovePx = topLeftS.y - gapPx - barHeightPx
+                val topBelowPx = bottomRightS.y + gapPx
+                val minTopPx = with(density) { 72.dp.toPx() }
+                val maxTopPx = viewportH - barHeightPx - with(density) { 12.dp.toPx() }
+                val yPx = if (topAbovePx >= minTopPx) topAbovePx else topBelowPx
+                // Left-anchor the pill to the selection's left. Assume ~360dp
+                // max chip stack, clamp so the pill stays fully in-viewport.
+                val estBarWidthPx = with(density) { 360.dp.toPx() }
+                val minLeftPx = with(density) { 12.dp.toPx() }
+                val maxLeftPx = (viewportW - estBarWidthPx).coerceAtLeast(minLeftPx)
+                val xPx = topLeftS.x.coerceIn(minLeftPx, maxLeftPx)
+                val yPxClamped = yPx.coerceIn(minTopPx, maxTopPx)
+                androidx.compose.ui.unit.DpOffset(
+                    x = with(density) { xPx.toDp() },
+                    y = with(density) { yPxClamped.toDp() },
+                )
+            }
 
 
             // Config bars split by attachment target — notes-app-style discipline:
@@ -344,7 +415,9 @@ fun HomeScreen(
                         }
                     },
                     fontFamilyResolver = { key -> io.ak1.drawbox.text.FontRegistry.resolve(key) },
-                    modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 76.dp),
+                    modifier = Modifier.align(Alignment.BottomCenter)
+                        .padding(bottom = 76.dp)
+                        .alpha(chromeAlpha),
                 )
             }
 
@@ -386,7 +459,17 @@ fun HomeScreen(
                         }
                     },
                     fontFamilyResolver = { key -> io.ak1.drawbox.text.FontRegistry.resolve(key) },
-                    modifier = Modifier.align(Alignment.TopEnd).padding(top = 72.dp, end = 12.dp),
+                    modifier = if (selectionAnchor != null) {
+                        Modifier.align(Alignment.TopStart)
+                            .padding(start = selectionAnchor.x, top = selectionAnchor.y)
+                            .alpha(chromeAlpha)
+                    } else {
+                        // Fallback: fixed top-right when selection is off-screen
+                        // or spans the viewport.
+                        Modifier.align(Alignment.TopEnd)
+                            .padding(top = 72.dp, end = 12.dp)
+                            .alpha(chromeAlpha)
+                    },
                 )
             }
 
@@ -399,7 +482,9 @@ fun HomeScreen(
                 onZoomOut = { viewModel.zoomBy(0.8f, ScreenCenter) },
                 onZoomReset = { viewModel.resetCamera() },
                 onSettingsClick = { drawerOpen = true },
-                modifier = Modifier.align(Alignment.TopEnd).padding(top = 12.dp, end = 12.dp),
+                modifier = Modifier.align(Alignment.TopEnd)
+                    .padding(top = 12.dp, end = 12.dp)
+                    .alpha(chromeAlpha),
             )
 
             // Bottom-left zoom (wide only). Narrow folds zoom into the top-right cluster.
@@ -409,7 +494,9 @@ fun HomeScreen(
                     onZoomIn = { viewModel.zoomBy(1.25f, ScreenCenter) },
                     onZoomOut = { viewModel.zoomBy(0.8f, ScreenCenter) },
                     onZoomReset = { viewModel.resetCamera() },
-                    modifier = Modifier.align(Alignment.BottomStart).padding(start = 16.dp, bottom = 24.dp),
+                    modifier = Modifier.align(Alignment.BottomStart)
+                        .padding(start = 16.dp, bottom = 24.dp)
+                        .alpha(chromeAlpha),
                 )
             }
 
@@ -448,7 +535,8 @@ fun HomeScreen(
                 items = controlsBarItems,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 24.dp),
+                    .padding(bottom = 24.dp)
+                    .alpha(chromeAlpha),
             )
 
 

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -345,7 +345,6 @@ fun HomeScreen(
                     },
                     fontFamilyResolver = { key -> io.ak1.drawbox.text.FontRegistry.resolve(key) },
                     modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 76.dp),
-                    expanded = false,
                 )
             }
 
@@ -388,22 +387,19 @@ fun HomeScreen(
                     },
                     fontFamilyResolver = { key -> io.ak1.drawbox.text.FontRegistry.resolve(key) },
                     modifier = Modifier.align(Alignment.TopEnd).padding(top = 72.dp, end = 12.dp),
-                    expanded = false,
                 )
             }
 
-            // Top-right cluster: zoom (only narrow), theme toggle, settings.
+            // Top-right cluster: zoom (only narrow) + settings. Theme moved
+            // into SettingsDrawer's View section.
             TopRightControls(
                 isNarrow = isNarrow,
                 scalePercent = state.viewport.scalePercent,
-                themeMode = themeMode,
-                onThemeModeChange = onThemeModeChange,
                 onZoomIn = { viewModel.zoomBy(1.25f, ScreenCenter) },
                 onZoomOut = { viewModel.zoomBy(0.8f, ScreenCenter) },
                 onZoomReset = { viewModel.resetCamera() },
                 onSettingsClick = { drawerOpen = true },
                 modifier = Modifier.align(Alignment.TopEnd).padding(top = 12.dp, end = 12.dp),
-                expanded = false,
             )
 
             // Bottom-left zoom (wide only). Narrow folds zoom into the top-right cluster.
@@ -414,7 +410,6 @@ fun HomeScreen(
                     onZoomOut = { viewModel.zoomBy(0.8f, ScreenCenter) },
                     onZoomReset = { viewModel.resetCamera() },
                     modifier = Modifier.align(Alignment.BottomStart).padding(start = 16.dp, bottom = 24.dp),
-                    expanded = false,
                 )
             }
 
@@ -454,7 +449,6 @@ fun HomeScreen(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(bottom = 24.dp),
-                expanded = false,
             )
 
 
@@ -481,6 +475,8 @@ fun HomeScreen(
             showGrid = showGrid.value,
             currentBgColor = state.bgColor,
             currentBgPattern = currentBgPattern,
+            themeMode = themeMode,
+            onThemeModeChange = onThemeModeChange,
             onDismiss = { drawerOpen = false },
             onDownloadSvg = { viewModel.exportSvg(); drawerOpen = false },
             onDownloadPng = { viewModel.saveBitmap(); drawerOpen = false },

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/HomeScreen.kt
@@ -136,8 +136,6 @@ fun HomeScreen(
     val selectedHasStrokeable = selectedDrawables.any {
         it is Element.Shape || it is Element.Path
     }
-    val showShapeStroke = isShapeMode || selectedHasStrokeable
-    val showCornerRadius = state.mode == Mode.RECTANGLE || state.mode == Mode.TRIANGLE || selectedRoundable.isNotEmpty()
     val currentRadius = if (selectedRoundable.isNotEmpty()) (selectedRoundable.first() as Element.Shape).cornerRadius
     else state.currentItemCornerRadius
     val currentStrokeStyle = when (val first = selectedDrawables.firstOrNull()) {
@@ -164,6 +162,25 @@ fun HomeScreen(
     val showStrokeToggle = selectedShapes.isNotEmpty()
     val currentFillColor = selectedShapes.firstOrNull()?.fillColor
     val currentStrokeEnabled = selectedShapes.firstOrNull()?.strokeEnabled ?: true
+    // Elements that support BOTH stroke and fill drive ControlsBar's split-disc
+    // swatch + the multi-target picker. Only closed shapes qualify — LINE and
+    // ARROW are stroke-only, paths and text likewise.
+    val hasFillableSelection = selectedShapes.any {
+        it.shapeType == ShapeType.RECTANGLE ||
+            it.shapeType == ShapeType.CIRCLE ||
+            it.shapeType == ShapeType.TRIANGLE
+    }
+    // Also let the split disc appear in fillable-shape tool modes with no
+    // selection, so the user can preconfigure fill BEFORE dropping the shape.
+    // Backed by State.currentItemFillColor / currentItemStrokeEnabled.
+    val isFillableToolMode = state.mode == Mode.RECTANGLE ||
+        state.mode == Mode.CIRCLE ||
+        state.mode == Mode.TRIANGLE
+    val showFillTarget = hasFillableSelection || (!hasSelection && isFillableToolMode)
+    val toolOrSelectionStrokeEnabled = if (hasFillableSelection)
+        currentStrokeEnabled else state.currentItemStrokeEnabled
+    val toolOrSelectionFillColor = if (hasFillableSelection)
+        currentFillColor else state.currentItemFillColor
 
     // Text controls — surfaced in TEXT mode (pre-configure the next insert)
     // OR when a single Text element is selected (edit existing). Multi-text
@@ -171,8 +188,6 @@ fun HomeScreen(
     // possibly-conflicting style values.
     val selectedTexts = selectedDrawables.filterIsInstance<Element.Text>()
     val singleSelectedText = selectedTexts.singleOrNull()?.takeIf { selectedDrawables.size == 1 }
-    val showTextControls = isTextMode || singleSelectedText != null
-    val showEditText = singleSelectedText != null
     // Current values follow the selected element when present; otherwise
     // fall back to the State defaults the next insert will use.
     val currentFontSize = singleSelectedText?.fontSize ?: state.currentItemFontSize
@@ -276,63 +291,91 @@ fun HomeScreen(
             val isNarrow = maxWidth < 600.dp
 
 
-            // Top-right unified context bar — merges shape config + selection
-            // actions into one pill. Rendered only when there's something to show.
-            val barVisible = showShapeStroke || showCornerRadius || showFill ||
-                showStrokeToggle || showTextControls || hasSelection
-            if (barVisible) {
-                val contextBarState = ContextBarState(
-                    strokeColor = currentShapeColor,
-                    strokeEnabled = currentStrokeEnabled,
-                    strokeStyle = currentStrokeStyle,
-                    strokeWidth = currentStrokeWidth,
-                    fillColor = currentFillColor,
-                    cornerRadius = currentRadius,
-                    fontSize = currentFontSize,
-                    textAlignment = currentTextAlignment,
-                    fontFamilyKey = currentFontFamilyKey,
-                    fontFamilyKeys = fontFamilyKeys,
-                )
-                val contextBarSlots = ContextBarSlots(
-                    showStroke = true,
-                    strokeToggleable = showStrokeToggle,
-                    showShapeStroke = showShapeStroke,
-                    showFill = showFill,
-                    showCornerRadius = showCornerRadius,
-                    showText = showTextControls,
-                    showEditText = showEditText,
-                    showSelectionActions = hasSelection,
-                )
+            // Config bars split by attachment target — notes-app-style discipline:
+            //  - Tool bar (bottom-center, above ControlsBar): configures the
+            //    active tool's NEXT stroke/insert. Shown when a configurable
+            //    tool mode is active AND nothing is selected.
+            //  - Selection bar (top-right): edits / acts on the current
+            //    selection. Shown when there IS a selection.
+            // Mutually exclusive by construction — the user's attention is on
+            // one thing at a time, so only one bar is ever visible.
+            val commonBarState = ContextBarState(
+                strokeColor = currentShapeColor,
+                strokeEnabled = currentStrokeEnabled,
+                strokeStyle = currentStrokeStyle,
+                strokeWidth = currentStrokeWidth,
+                fillColor = currentFillColor,
+                cornerRadius = currentRadius,
+                fontSize = currentFontSize,
+                textAlignment = currentTextAlignment,
+                fontFamilyKey = currentFontFamilyKey,
+                fontFamilyKeys = fontFamilyKeys,
+            )
+
+            val toolBarVisible = !hasSelection && (isShapeMode || isTextMode)
+            if (toolBarVisible) {
                 ContextBar(
-                    state = contextBarState,
-                    slots = contextBarSlots,
+                    state = commonBarState,
+                    slots = ContextBarSlots(
+                        // Color already lives on ControlsBar's swatch — no need
+                        // to duplicate it on the tool config bar. This keeps the
+                        // tool bar focused on options ControlsBar doesn't
+                        // expose (style, width, corner, size, align, family).
+                        showStroke = false,
+                        strokeToggleable = false,
+                        showShapeStroke = isShapeMode,
+                        showFill = false,
+                        showCornerRadius = state.mode == Mode.RECTANGLE ||
+                            state.mode == Mode.TRIANGLE,
+                        showText = isTextMode,
+                        showEditText = false,
+                        showSelectionActions = false,
+                    ),
                     onIntent = { intent ->
                         when (intent) {
-                            is ContextBarIntent.SetStrokeColor ->
-                                if (hasSelection) viewModel.setSelectionColor(intent.color)
-                                else viewModel.setColor(intent.color)
-                            is ContextBarIntent.SetStrokeEnabled ->
-                                viewModel.setSelectionStrokeEnabled(intent.enabled)
-                            is ContextBarIntent.SetStrokeStyle ->
-                                if (hasSelection) viewModel.setSelectionStrokeStyle(intent.style)
-                                else viewModel.setStrokeStyle(intent.style)
-                            is ContextBarIntent.SetStrokeWidth ->
-                                if (hasSelection) viewModel.setSelectionStrokeWidth(intent.width)
-                                else viewModel.setStrokeWidth(intent.width)
-                            is ContextBarIntent.SetFillColor ->
-                                viewModel.setSelectionFillColor(intent.color)
-                            is ContextBarIntent.SetCornerRadius ->
-                                if (selectedRoundable.isNotEmpty()) viewModel.setSelectionCornerRadius(intent.radius)
-                                else viewModel.setCornerRadius(intent.radius)
-                            is ContextBarIntent.SetFontSize ->
-                                if (singleSelectedText != null) viewModel.setSelectionFontSize(intent.size)
-                                else viewModel.setFontSize(intent.size)
-                            is ContextBarIntent.SetTextAlignment ->
-                                if (singleSelectedText != null) viewModel.setSelectionTextAlignment(intent.alignment)
-                                else viewModel.setTextAlignment(intent.alignment)
-                            is ContextBarIntent.SetFontFamily ->
-                                if (singleSelectedText != null) viewModel.setSelectionFontFamily(intent.key)
-                                else viewModel.setFontFamily(intent.key)
+                            is ContextBarIntent.SetStrokeColor -> viewModel.setColor(intent.color)
+                            is ContextBarIntent.SetStrokeStyle -> viewModel.setStrokeStyle(intent.style)
+                            is ContextBarIntent.SetStrokeWidth -> viewModel.setStrokeWidth(intent.width)
+                            is ContextBarIntent.SetCornerRadius -> viewModel.setCornerRadius(intent.radius)
+                            is ContextBarIntent.SetFontSize -> viewModel.setFontSize(intent.size)
+                            is ContextBarIntent.SetTextAlignment -> viewModel.setTextAlignment(intent.alignment)
+                            is ContextBarIntent.SetFontFamily -> viewModel.setFontFamily(intent.key)
+                            else -> {}
+                        }
+                    },
+                    fontFamilyResolver = { key -> io.ak1.drawbox.text.FontRegistry.resolve(key) },
+                    modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 76.dp),
+                    expanded = false,
+                )
+            }
+
+            if (hasSelection) {
+                ContextBar(
+                    state = commonBarState,
+                    slots = ContextBarSlots(
+                        // Color affordance owned by ControlsBar's swatch (plain
+                        // or split-disc based on hasFillableSelection). The
+                        // selection bar focuses on style/geometry/actions.
+                        showStroke = false,
+                        strokeToggleable = false,
+                        showShapeStroke = selectedHasStrokeable,
+                        showFill = false,
+                        showCornerRadius = selectedRoundable.isNotEmpty(),
+                        showText = singleSelectedText != null,
+                        showEditText = singleSelectedText != null,
+                        showSelectionActions = true,
+                    ),
+                    onIntent = { intent ->
+                        when (intent) {
+                            is ContextBarIntent.SetStrokeColor -> viewModel.setSelectionColor(intent.color)
+                            is ContextBarIntent.SetStrokeEnabled -> viewModel.setSelectionStrokeEnabled(intent.enabled)
+                            is ContextBarIntent.SetStrokeStyle -> viewModel.setSelectionStrokeStyle(intent.style)
+                            is ContextBarIntent.SetStrokeWidth -> viewModel.setSelectionStrokeWidth(intent.width)
+                            is ContextBarIntent.SetFillColor -> viewModel.setSelectionFillColor(intent.color)
+                            is ContextBarIntent.SetCornerRadius -> viewModel.setSelectionCornerRadius(intent.radius)
+                            is ContextBarIntent.SetFontSize -> viewModel.setSelectionFontSize(intent.size)
+                            is ContextBarIntent.SetTextAlignment -> viewModel.setSelectionTextAlignment(intent.alignment)
+                            is ContextBarIntent.SetFontFamily -> viewModel.setSelectionFontFamily(intent.key)
                             ContextBarIntent.EditText -> singleSelectedText?.let { target ->
                                 editingTextId = target.id
                                 editDraft = target.text
@@ -382,6 +425,12 @@ fun HomeScreen(
                     canUndo = canUndo,
                     canRedo = canRedo,
                     strokeColor = currentShapeColor,
+                    // Split-disc swatch + multi-target picker light up for
+                    // fillable-shape selections AND for fillable-shape tool
+                    // modes with no selection (preconfigure fill before draw).
+                    showFillTarget = showFillTarget,
+                    strokeEnabled = toolOrSelectionStrokeEnabled,
+                    fillColor = toolOrSelectionFillColor,
                 ),
                 dispatch = { intent ->
                     when (intent) {
@@ -391,6 +440,12 @@ fun HomeScreen(
                         is ControlsBarIntent.SetStrokeColor ->
                             if (hasSelection) viewModel.setSelectionColor(intent.color)
                             else viewModel.setColor(intent.color)
+                        is ControlsBarIntent.SetStrokeEnabled ->
+                            if (hasSelection) viewModel.setSelectionStrokeEnabled(intent.enabled)
+                            else viewModel.setStrokeEnabled(intent.enabled)
+                        is ControlsBarIntent.SetFillColor ->
+                            if (hasSelection) viewModel.setSelectionFillColor(intent.color)
+                            else viewModel.setFillColor(intent.color)
                     }
                 },
             )

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/ReplayScreen.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/ReplayScreen.kt
@@ -90,7 +90,7 @@ fun ReplayScreen(
                 .padding(top = 12.dp, end = 12.dp)
                 .shadow(elevation = 3.dp, shape = CircleShape, clip = false)
                 .size(40.dp)
-                .background(MaterialTheme.colorScheme.surface, CircleShape),
+                .background(MaterialTheme.colorScheme.surfaceContainer, CircleShape),
         ) {
             Icon(Icons.Filled.Close, contentDescription = "Close replay")
         }
@@ -103,8 +103,7 @@ fun ReplayScreen(
                 .shadow(elevation = 3.dp, shape = CircleShape, clip = false)
                 .fillMaxWidth(0.85f),
             shape = CircleShape,
-            color = MaterialTheme.colorScheme.surface,
-            tonalElevation = 4.dp,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             Row(
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/SettingsDrawer.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/SettingsDrawer.kt
@@ -26,12 +26,15 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.GridOn
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Pattern
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Upload
@@ -50,6 +53,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import drawboxsample.shared.generated.resources.Res
+import io.ak1.drawboxsample.ui.theme.ThemeMode
 import drawboxsample.shared.generated.resources.bg_graph_paper
 import drawboxsample.shared.generated.resources.bg_hideout
 import drawboxsample.shared.generated.resources.bg_texture
@@ -82,6 +86,8 @@ fun SettingsDrawer(
     showGrid: Boolean,
     currentBgColor: Color,
     currentBgPattern: BgPatternPreset?,
+    themeMode: ThemeMode,
+    onThemeModeChange: (ThemeMode) -> Unit,
     onDismiss: () -> Unit,
     onDownloadSvg: () -> Unit,
     onDownloadPng: () -> Unit,
@@ -183,6 +189,7 @@ fun SettingsDrawer(
                     )
 
                     SectionLabel("View")
+                    ThemeRow(current = themeMode, onSelect = onThemeModeChange)
                     GridSwitchRow(checked = showGrid, onCheckedChange = onToggleGrid)
 
                     SectionLabel("Danger")
@@ -381,6 +388,76 @@ private fun PatternChip(
             color = if (selected) MaterialTheme.colorScheme.primary
             else MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+/**
+ * Three-way theme picker rendered as icon buttons trailing a labeled row.
+ * Matches the drawer's row idiom — icon+label+trailing content — instead of
+ * a floating cycle button.
+ */
+@Composable
+private fun ThemeRow(current: ThemeMode, onSelect: (ThemeMode) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        val icon = when (current) {
+            ThemeMode.SYSTEM -> Icons.Filled.BrightnessAuto
+            ThemeMode.LIGHT -> Icons.Filled.LightMode
+            ThemeMode.DARK -> Icons.Filled.DarkMode
+        }
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(
+            text = "Theme",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(end = 8.dp),
+        )
+        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                ThemeChoice(Icons.Filled.BrightnessAuto, "System", current == ThemeMode.SYSTEM) {
+                    onSelect(ThemeMode.SYSTEM)
+                }
+                ThemeChoice(Icons.Filled.LightMode, "Light", current == ThemeMode.LIGHT) {
+                    onSelect(ThemeMode.LIGHT)
+                }
+                ThemeChoice(Icons.Filled.DarkMode, "Dark", current == ThemeMode.DARK) {
+                    onSelect(ThemeMode.DARK)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ThemeChoice(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val bg = if (selected) MaterialTheme.colorScheme.primaryContainer
+    else Color.Transparent
+    val tint = if (selected) MaterialTheme.colorScheme.onPrimaryContainer
+    else MaterialTheme.colorScheme.onSurfaceVariant
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .clip(CircleShape)
+            .background(bg)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(icon, contentDescription = label, tint = tint, modifier = Modifier.size(18.dp))
     }
 }
 

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/SettingsDrawer.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/SettingsDrawer.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import drawboxsample.shared.generated.resources.Res
 import drawboxsample.shared.generated.resources.bg_graph_paper
 import drawboxsample.shared.generated.resources.bg_hideout
@@ -106,7 +105,7 @@ fun SettingsDrawer(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.4f))
+                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.4f))
                     .clickable(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() },
@@ -130,8 +129,7 @@ fun SettingsDrawer(
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = {},
                     ),
-                color = MaterialTheme.colorScheme.surface,
-                tonalElevation = 4.dp,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 shape = RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp),
             ) {
                 Column(
@@ -211,8 +209,7 @@ private fun DrawerHeader(onDismiss: () -> Unit) {
     ) {
         Text(
             text = "Settings",
-            fontSize = 18.sp,
-            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 4.dp),
         )
@@ -226,7 +223,7 @@ private fun DrawerHeader(onDismiss: () -> Unit) {
 private fun SectionLabel(text: String) {
     Text(
         text = text.uppercase(),
-        fontSize = 10.sp,
+        style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.padding(start = 20.dp, top = 14.dp, bottom = 6.dp),
@@ -252,7 +249,7 @@ private fun DrawerRow(
         Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(20.dp))
         Text(
             text = label,
-            fontSize = 14.sp,
+            style = MaterialTheme.typography.bodyLarge,
             color = tint,
             modifier = Modifier.padding(end = 8.dp),
         )
@@ -282,7 +279,7 @@ private fun BgColorRow(currentBgColor: Color, onClick: () -> Unit) {
         )
         Text(
             text = "Background color",
-            fontSize = 14.sp,
+            style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(end = 8.dp),
         )
@@ -316,7 +313,7 @@ private fun BgPatternRow(
             )
             Text(
                 text = "Background pattern",
-                fontSize = 14.sp,
+                style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
         }
@@ -380,7 +377,7 @@ private fun PatternChip(
         }
         Text(
             text = label,
-            fontSize = 10.sp,
+            style = MaterialTheme.typography.labelSmall,
             color = if (selected) MaterialTheme.colorScheme.primary
             else MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -405,7 +402,7 @@ private fun GridSwitchRow(checked: Boolean, onCheckedChange: (Boolean) -> Unit) 
         )
         Text(
             text = "Show grid",
-            fontSize = 14.sp,
+            style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(end = 8.dp),
         )

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/TopRightControls.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/TopRightControls.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.shadow
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingToolbarDefaults
@@ -30,7 +32,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.ak1.drawboxsample.ui.theme.ThemeMode
 import io.ak1.drawboxsample.ui.theme.next
 
@@ -129,7 +130,7 @@ private fun RowScope.ZoomCluster(
         onClick = onZoomOut,
         modifier = Modifier.size(36.dp),
     ) {
-        Text("−", fontSize = 18.sp, color = MaterialTheme.colorScheme.onSurface)
+        Icon(Icons.Filled.Remove, contentDescription = "Zoom out")
     }
     Box(
         modifier = Modifier
@@ -141,7 +142,7 @@ private fun RowScope.ZoomCluster(
     ) {
         Text(
             text = "$scalePercent%",
-            fontSize = 12.sp,
+            style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
     }
@@ -149,7 +150,7 @@ private fun RowScope.ZoomCluster(
         onClick = onZoomIn,
         modifier = Modifier.size(36.dp),
     ) {
-        Text("+", fontSize = 18.sp, color = MaterialTheme.colorScheme.onSurface)
+        Icon(Icons.Filled.Add, contentDescription = "Zoom in")
     }
 }
 

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/TopRightControls.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/TopRightControls.kt
@@ -2,6 +2,8 @@
 
 package io.ak1.drawboxsample.ui.components
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +14,7 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.draw.shadow
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -125,15 +128,24 @@ private fun RowScope.ZoomCluster(
     ) {
         Icon(Icons.Filled.Remove, contentDescription = "Zoom out")
     }
-    // Hide the percent readout at exact 100% — reading "100%" every frame is
-    // noise. The reset gesture still lives on this Box's click, so we render
-    // an invisible-but-clickable spacer of the same width to keep the toolbar
-    // dimensions stable regardless of zoom.
+    // Collapse the percent readout to zero width at exact 100% — the toolbar
+    // contracts horizontally so [-] and [+] sit right next to each other, and
+    // expands back with a spring-like tween on the first non-100 tick. Reset
+    // gesture only exists when the label is visible (nothing to reset TO at
+    // 100%).
+    val labelWidth by animateDpAsState(
+        targetValue = if (scalePercent == 100) 0.dp else 48.dp,
+        animationSpec = tween(durationMillis = 180),
+        label = "zoomLabelWidth",
+    )
     Box(
         modifier = Modifier
             .align(Alignment.CenterVertically)
-            .width(48.dp)
-            .clickable(onClick = onZoomReset)
+            .width(labelWidth)
+            .then(
+                if (scalePercent != 100) Modifier.clickable(onClick = onZoomReset)
+                else Modifier,
+            )
             .padding(vertical = 4.dp),
         contentAlignment = Alignment.Center,
     ) {

--- a/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/TopRightControls.kt
+++ b/shared/src/commonMain/kotlin/io/ak1/drawboxsample/ui/components/TopRightControls.kt
@@ -15,9 +15,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.shadow
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.BrightnessAuto
-import androidx.compose.material.icons.filled.DarkMode
-import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -32,28 +29,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.ak1.drawboxsample.ui.theme.ThemeMode
-import io.ak1.drawboxsample.ui.theme.next
 
 /**
  * Top-right floating control cluster.
  *
- * Wide screens: [Theme] [Settings] only — zoom lives at bottom-left.
- * Narrow screens: [Zoom -/%/+] [Theme] [Settings] folded into a single bar so
- * there's only one floating control row on small viewports.
+ * Wide screens: just [Settings] — zoom lives at bottom-left, theme moved into
+ * the settings drawer.
+ * Narrow screens: [Zoom -/%/+] | [Settings] folded into a single bar so there's
+ * only one floating control row on small viewports.
  */
 @Composable
 fun TopRightControls(
     isNarrow: Boolean,
     scalePercent: Int,
-    themeMode: ThemeMode,
-    onThemeModeChange: (ThemeMode) -> Unit,
     onZoomIn: () -> Unit,
     onZoomOut: () -> Unit,
     onZoomReset: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
-    expanded: Boolean = true,
+    expanded: Boolean = false,
 ) {
     HorizontalFloatingToolbar(
         expanded = expanded,
@@ -78,7 +72,6 @@ fun TopRightControls(
                     color = MaterialTheme.colorScheme.outlineVariant,
                 )
             }
-            ThemeToggleButton(themeMode = themeMode, onCycle = { onThemeModeChange(themeMode.next()) })
             IconButton(
                 onClick = onSettingsClick,
                 modifier = Modifier.size(36.dp),
@@ -99,7 +92,7 @@ fun ZoomToolbar(
     onZoomOut: () -> Unit,
     onZoomReset: () -> Unit,
     modifier: Modifier = Modifier,
-    expanded: Boolean = true,
+    expanded: Boolean = false,
 ) {
     HorizontalFloatingToolbar(
         expanded = expanded,
@@ -132,6 +125,10 @@ private fun RowScope.ZoomCluster(
     ) {
         Icon(Icons.Filled.Remove, contentDescription = "Zoom out")
     }
+    // Hide the percent readout at exact 100% — reading "100%" every frame is
+    // noise. The reset gesture still lives on this Box's click, so we render
+    // an invisible-but-clickable spacer of the same width to keep the toolbar
+    // dimensions stable regardless of zoom.
     Box(
         modifier = Modifier
             .align(Alignment.CenterVertically)
@@ -140,11 +137,13 @@ private fun RowScope.ZoomCluster(
             .padding(vertical = 4.dp),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = "$scalePercent%",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
+        if (scalePercent != 100) {
+            Text(
+                text = "$scalePercent%",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
     }
     IconButton(
         onClick = onZoomIn,
@@ -154,20 +153,3 @@ private fun RowScope.ZoomCluster(
     }
 }
 
-@Composable
-private fun ThemeToggleButton(
-    themeMode: ThemeMode,
-    onCycle: () -> Unit,
-) {
-    val (vector, label) = when (themeMode) {
-        ThemeMode.SYSTEM -> Icons.Filled.BrightnessAuto to "Theme: System"
-        ThemeMode.LIGHT -> Icons.Filled.LightMode to "Theme: Light"
-        ThemeMode.DARK -> Icons.Filled.DarkMode to "Theme: Dark"
-    }
-    IconButton(
-        onClick = onCycle,
-        modifier = Modifier.size(36.dp),
-    ) {
-        Icon(imageVector = vector, contentDescription = label)
-    }
-}


### PR DESCRIPTION
feat/drawbox-ui-module: MD3 Expressive UX pass + notes-app quality delta

Follow-up work on top of the drawbox-ui extraction (#104). Ships the review + polish items surfaced during the MD3 Expressive audit and the Samsung / OPPO Notes comparison. Tracked in #105.

  Summary

  - MD3 Expressive polish across the demo, drawbox-ui, and DrawBox library — deprecated background role dropped, surface-container tonal roles used correctly, typography + shape tokens replace hardcoded values, MultiTargetColorPicker gets a proper MD3
   dialog container.
  - Notes-app UX pass — single split-disc color affordance for fillable shapes; selection ContextBar anchors to selection bounds instead of a fixed corner; floating chrome fades to 0.35 α during touch gestures; each drawing tool now remembers its own
  style settings across mode switches.
  - Domain additions — per-tool ToolSettings snapshot map, tool-level fill / stroke-enabled fields, corresponding Intent variants and controller methods. Existing tests pass — all additions are additive.

  What changed by area
  
  DrawBox library (domain)

  - State.currentItemFillColor: Color? and State.currentItemStrokeEnabled: Boolean — tool defaults applied to newly inserted Element.Shapes.
  - State.toolMemory: Map<Mode, ToolSettings> — per-mode style snapshot. SetMode captures the outgoing mode's snapshot and restores the incoming mode's (when present). Utility modes (SELECT, ERASER, PAN) pass through unchanged.
  - ToolSettings data class + Mode.persistsSettings() gating helper.
  - Intent.SetFillColor(color: Color?) and Intent.SetStrokeEnabled(enabled: Boolean) — tool-level counterparts to the existing selection-form intents. Reducer wires both.
  - UseCase.insertNewShape — new default-back-compat fillColor and strokeEnabled params (existing tests unchanged).
  - DrawBoxController.setFillColor(...) / setStrokeEnabled(...) — public wrappers.

  drawbox-ui

  - ControlsBarState: new showFillTarget, strokeEnabled, fillColor fields.
  - ControlsBarIntent: new SetFillColor, SetStrokeEnabled variants.
  - New SplitColorSwatch composable — 45°-partitioned disc (top-left = border, bottom-right = fill) with per-half diagonal-slash idiom for off states.
  - New MultiTargetColorPicker composable in picker/ColorPickers.kt — Border / Fill tabs, off-toggle, RangVikalp seeded per-tab. Uses MD3 dialog container (extraLarge shape + surfaceContainerHigh).
  - New colorsContextItem builder — consolidates stroke + strokeEnabled + fill into one chip with a vertical submenu (visual grouping via new HorizontalDivider support in the vertical ExpandableFloatingToolbar submenu).
  - ExpandableFloatingToolbar: separator support inside vertical submenu.
  - All floating-toolbar expanded defaults flipped true → false (matches every consumer's call-site value).
  - selectionContextItems: dropped the Clear selection chip — tap-outside / Esc / tool switch all deselect for free. ContextBarIntent.ClearSelection retained for programmatic consumers.

  Demo (shared/)

  - App.kt root Surface uses colorScheme.surface (not deprecated background).
  - HomeScreen:
    - Split single ContextBar into two mutually-exclusive bars — tool bar (bottom-center above ControlsBar) when !hasSelection && (isShapeMode || isTextMode), selection bar (position-anchored) when hasSelection.
    - Selection bar anchored to selection bounds via viewport.worldToScreen(...). Falls back to fixed top-right when off-screen or when the selection spans > 90 % of the viewport.
    - Pointer peek on PointerEventPass.Initial sets an isGesturing flag → all floating chrome fades to 0.35 α while any pointer is pressed. Doesn't consume events.
    - Wired showFillTarget = hasFillableSelection || isFillableToolMode, plus new fill / stroke-enabled dispatchers.
  - SettingsDrawer: added 3-way Theme picker row (System / Light / Dark) in the View section. Sheet uses surfaceContainerHigh + colorScheme.scrim. Font sizes replaced with typography tokens.
  - TopRightControls: theme toggle removed (now lives in the drawer). Zoom label collapses to width-0 at 100 % with a 180 ms tween; expands back on the next non-100 tick. Text glyphs + / − replaced with Icons.Filled.Add / Remove.
  - ReplayScreen: surfaceContainer / surfaceContainerHigh for chrome.
