### PR TITLE
docs(changelog): promote Unreleased to 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The `2.0.x` line is the Kotlin Multiplatform rewrite. The `1.x` line was an Andr
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-07-14
+
+First stable release of the `2.1` line, promoting the two `2.1.0-alpha`
+pre-releases plus in-place text editing, configurable selection chrome, and
+the web font-differentiation fix. The new `2.1` surfaces (image / text
+elements, `io.ak1.drawbox.input`, pen-pressure sample fields, Kotlin/JS
+publishing) are now stable; see the earlier alpha entries for their details
+and the [migration note](#migration-20x--21x) for the one `Element.Path`
+change.
+
 ### Added
 - **In-place text editing gestures (#83).** Double-tapping an `Element.Text`
   in `SELECT` mode — or tapping an already-selected one again — now opens the
@@ -439,7 +449,8 @@ under semver. Incubating surfaces (collab plumbing, advanced eraser
 modes, etc.) are gated behind opt-in annotations and may evolve in
 minor versions.
 
-[Unreleased]: https://github.com/akshay2211/DrawBox/compare/v2.1.0-alpha02...HEAD
+[Unreleased]: https://github.com/akshay2211/DrawBox/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/akshay2211/DrawBox/compare/v2.1.0-alpha02...v2.1.0
 [2.1.0-alpha02]: https://github.com/akshay2211/DrawBox/compare/v2.1.0-alpha01...v2.1.0-alpha02
 [2.1.0-alpha01]: https://github.com/akshay2211/DrawBox/compare/v2.0.0...v2.1.0-alpha01
 [2.0.0]: https://github.com/akshay2211/DrawBox/compare/2.0.0-alpha02...v2.0.0

--- a/DrawBox/gradle.properties
+++ b/DrawBox/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=io.ak1
 POM_ARTIFACT_ID=drawbox
-VERSION_NAME=2.1.0-alpha02
+VERSION_NAME=2.1.0
 
 POM_NAME=DrawBox
 POM_DESCRIPTION=A cross-platform drawing SDK built with Kotlin Multiplatform.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ controller.events.collect { event ->  // Listen to events
 
 ## Download
 
-Latest Version: **2.1.0-alpha02** (KMP Preview)
+Latest Version: **2.1.0** (KMP Preview)
 
 [![Download](https://img.shields.io/badge/Download-blue.svg?style=flat-square)](https://search.maven.org/artifact/io.ak1/drawbox) or grab via Gradle:
 
@@ -195,7 +195,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.ak1:drawbox:2.1.0-alpha02")
+    implementation("io.ak1:drawbox:2.1.0")
 }
 ```
 
@@ -206,7 +206,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.ak1:drawbox:2.1.0-alpha02'
+    implementation 'io.ak1:drawbox:2.1.0'
 }
 ```
 
@@ -215,13 +215,13 @@ dependencies {
 <dependency>
   <groupId>io.ak1</groupId>
   <artifactId>drawbox</artifactId>
-  <version>2.1.0-alpha02</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
 ### Ivy
 ```xml
-<dependency org='io.ak1' name='drawbox' rev='2.1.0-alpha02'>
+<dependency org='io.ak1' name='drawbox' rev='2.1.0'>
   <artifact name='drawbox' ext='pom' ></artifact>
 </dependency>
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,14 +23,14 @@ repositories {
 ### Kotlin DSL (Recommended)
 ```kotlin
 dependencies {
-    implementation("io.ak1:drawbox:2.1.0-alpha02")
+    implementation("io.ak1:drawbox:2.1.0")
 }
 ```
 
 ### Groovy DSL
 ```groovy
 dependencies {
-    implementation 'io.ak1:drawbox:2.1.0-alpha02'
+    implementation 'io.ak1:drawbox:2.1.0'
 }
 ```
 
@@ -39,13 +39,13 @@ dependencies {
 <dependency>
   <groupId>io.ak1</groupId>
   <artifactId>drawbox</artifactId>
-  <version>2.1.0-alpha02</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 
 ### Ivy
 ```xml
-<dependency org='io.ak1' name='drawbox' rev='2.1.0-alpha02'>
+<dependency org='io.ak1' name='drawbox' rev='2.1.0'>
   <artifact name='drawbox' ext='pom' ></artifact>
 </dependency>
 ```
@@ -126,7 +126,7 @@ If you get "Unresolved reference" errors:
 If you have dependency version conflicts:
 ```kotlin
 dependencies {
-    implementation("io.ak1:drawbox:2.1.0-alpha02") {
+    implementation("io.ak1:drawbox:2.1.0") {
         exclude(group = "androidx.compose.runtime", module = "runtime")
     }
 }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -237,7 +237,7 @@ fun SimpleDrawingApp() {
 ## Troubleshooting
 
 ### "Cannot resolve symbol DrawBox"
-- Ensure DrawBox is installed: `implementation("io.ak1:drawbox:2.1.0-alpha02")`
+- Ensure DrawBox is installed: `implementation("io.ak1:drawbox:2.1.0")`
 - Run `./gradlew clean` and sync Gradle
 
 ### Canvas appears but doesn't respond to touches

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ Uses the **MVI (Model-View-Intent)** pattern with immutable state management, ma
 
 | Metric | Value |
 |--------|-------|
-| **Latest Version** | 2.1.0-alpha02 |
+| **Latest Version** | 2.1.0 |
 | **Platforms** | Android, iOS, Web, Desktop |
 | **Architecture** | MVI Pattern |
 | **State Management** | Immutable, Functional |
@@ -75,7 +75,7 @@ Add to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.ak1:drawbox:2.1.0-alpha02")
+    implementation("io.ak1:drawbox:2.1.0")
 }
 ```
 


### PR DESCRIPTION
## What

Promotes the `[Unreleased]` CHANGELOG section to a dated **`[2.1.0] — 2026-07-14`** release entry, matching the `VERSION_NAME=2.1.0` shipped in `385b0a3`.

## Changes

- Adds a `[2.1.0]` heading with a short release summary (stabilizes the `2.1.0-alpha01/02` surfaces plus text editing, configurable selection chrome, and the web font fix).
- Opens a fresh empty `[Unreleased]` section on top.
- Updates the compare links: new `[2.1.0]` link and retargets `[Unreleased]` to `v2.1.0...HEAD`.

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)